### PR TITLE
Create a global functions stylesheet

### DIFF
--- a/components/_side-panel.scss
+++ b/components/_side-panel.scss
@@ -10,27 +10,21 @@ $side-panel-default-settings: (
     background-color: #e1e5ea,
     button-size: 35px,
     height: rem-calc(60)
-  )
-);
-
-$side-panel-default-actions: (
-  'navigation': (
-    previous: angle-left,
-    next: angle-right
+  ),
+  actions: (
+    navigation: (
+      previous: angle-left,
+      next: angle-right
+    )
   )
 );
 
 $side-panel:
   if(global-variable-exists(side-panel),
-    map-merge($side-panel, $side-panel-default-settings),
+    map-merge-settings($side-panel-default-settings, $side-panel),
     $side-panel-default-settings
-);
-
-$side-panel-actions:
-  if(global-variable-exists(side-panel-actions),
-    map-merge($side-panel-actions, $side-panel-default-actions),
-    $side-panel-default-actions
   );
+
 
 $include-html-paint-side-panel: true !default;
 
@@ -162,6 +156,8 @@ $include-html-paint-side-panel: true !default;
 }
 
 @mixin side-panel-actions {
+  $side-panel-actions: map-get($side-panel, actions);
+
   @each $action-group, $actions in $side-panel-actions {
     .#{$action-group}-actions {
       @each $action, $icon in $actions {

--- a/components/_side-panel.scss
+++ b/components/_side-panel.scss
@@ -69,10 +69,6 @@ $include-html-paint-side-panel: true !default;
     overflow-y: auto;
     position: relative;
 
-    section {
-      @extend %grid-row;
-    }
-
     @media #{$small-only} {
       @include side-panel-size(small);
     }

--- a/globals/_functions.scss
+++ b/globals/_functions.scss
@@ -1,0 +1,49 @@
+@function map-set($map, $keys, $value) {
+  $maps: ($map,);
+  $result: null;
+
+  @if type-of(nth($keys, -1)) == "map" {
+    @warn "The last key you specified is a map; it will be overrided with `#{$value}`.";
+  }
+
+  @if length($keys) == 1 {
+    @return map-merge($map, ($keys: $value));
+  }
+
+  @for $i from 1 through length($keys) - 1 {
+    $current-key: nth($keys, $i);
+    $current-map: nth($maps, -1);
+    $current-get: map-get($current-map, $current-key);
+    @if $current-get == null {
+      @error "Key `#{$key}` doesn't exist at current level in map.";
+    }
+    $maps: append($maps, $current-get);
+  }
+
+  @for $i from length($maps) through 1 {
+    $current-map: nth($maps, $i);
+    $current-key: nth($keys, $i);
+    $current-val: if($i == length($maps), $value, $result);
+    $result: map-merge($current-map, ($current-key: $current-val));
+  }
+
+  @return $result;
+}
+
+@function map-merge-settings($default-map, $map) {
+  $merged-map: $default-map;
+
+  @each $settings-group, $settings in $map {
+
+    @if type-of($settings) == "map" {
+
+      @each $setting, $value in $settings {
+        $merged-map: map-set($merged-map, $settings-group $setting, $value);
+      }
+    } @else {
+      $merged-map: map-set($merged-map, $settings-group, $settings);
+    }
+  }
+
+  @return $merged-map;
+}

--- a/globals/_functions.scss
+++ b/globals/_functions.scss
@@ -34,9 +34,7 @@
   $merged-map: $default-map;
 
   @each $settings-group, $settings in $map {
-
     @if type-of($settings) == "map" {
-
       @each $setting, $value in $settings {
         $merged-map: map-set($merged-map, $settings-group $setting, $value);
       }

--- a/paint.scss
+++ b/paint.scss
@@ -1,5 +1,6 @@
 @import "bower_components/foundation/scss/foundation/functions";
 
+@import "globals/functions";
 @import "globals/settings";
 
 @import "bower_components/foundation/scss/normalize";


### PR DESCRIPTION
### Introducing Sass functions for setting nested maps.

**How it is supposed to work**

In any application's `paint-settings.scss` we would have
```scss
$component: (
  settings-group: (
    setting1: value1,
    setting2: value2
  ),
  settings-group3: (
    setting3: value3
  )
)
```
with paint holding the default component settings:
```scss
$component-defaults: (
  settings-group: (
    setting1: value1,
    setting2: value2,
    setting3: value3,
  ),
  settings-group2: (
    setting1: value1,
    setting2: value2,
    setting3: value3,
  ),
  settings-group3: (
    sub-settings-group: (
      setting1: value1,
      setting2: value2,
      setting3: value3,
    )
  )
)
```

Then each component is going to merge all settings into a single map, overriding default settings with custom ones:

```scss
$component:
  if(global-variable-exists(component),
    map-merge-settings($component-defaults, $component),
    $component-defaults
  );
```

This way the map merging logic is kept away from the applications.
The reason why `if(global-variable-exists(component)` cannot be part of the `map-merge-settings` function is the fact that Sass is going to return an error if `$component` is not defined _(which is going to be the case in most applications, where the default settings are not overridden)_

**Other changes**:
* Use a single-configuration settings map for the side panel
* **Hotfix** side panel bug where sections were extended with `%grid-row` by default