### PR TITLE
Extract and refactor the quick-jump component from Phoenix

### DIFF
--- a/components/_layout.scss
+++ b/components/_layout.scss
@@ -8,7 +8,7 @@ $layout-sidebar-footer-avatar-selector: '.avatar' !default;
 $layout-sidebar-footer-title-selector: '.name' !default;
 $layout-sidebar-footer-actions-selector: '.actions' !default;
 $layout-sidebar-footer-actions-icon: cog !default;
-$layout-sidebar-header-height: rem-calc(60) !default;
+$layout-sidebar-header-height: 60px !default;
 $layout-sidebar-header-logo-height: $layout-sidebar-header-height * .5 !default;
 $layout-sidebar-header-selector: '> header' !default;
 $layout-sidebar-heading-font-size: $small-font-size !default;

--- a/components/_quick-jump.scss
+++ b/components/_quick-jump.scss
@@ -4,8 +4,8 @@ $quick-jump-default-settings: (
   bar: (
     background-color: #e1e5ea,
     active-background-color: $white,
-    icon-size: rem-calc($button-icon-size),
-    height: rem-calc($layout-sidebar-header-height)
+    icon-size: $button-icon-size,
+    height: $layout-sidebar-header-height
   ),
   results: (
     background-color: #f2f2f2,
@@ -210,7 +210,7 @@ $quick-jump-default-settings: (
   .empty-message {
     height: quick-jump-settings(bar, height);
     line-height: quick-jump-settings(bar, height);
-    padding-left: $column-gutter + quick-jump-settings(bar, icon-size);
+    padding-left: $column-gutter + rem-calc(quick-jump-settings(bar, icon-size));
   }
 }
 

--- a/components/_quick-jump.scss
+++ b/components/_quick-jump.scss
@@ -119,7 +119,7 @@ $quick-jump-default-settings: (
 }
 
 %quick-jump-actions-section {
-  $actions-button-size: $button-icon-size;
+  $actions-button-size: quick-jump-settings(bar, icon-size);
 
   padding: 0 $column-gutter / 2;
   position: absolute;

--- a/components/_quick-jump.scss
+++ b/components/_quick-jump.scss
@@ -4,7 +4,7 @@ $quick-jump-default-settings: (
   bar: (
     background-color: #e1e5ea,
     active-background-color: $white,
-    icon-size: $button-icon-size,
+    icon-size: rem-calc($button-icon-size),
     height: $layout-sidebar-header-height
   ),
   results: (
@@ -210,7 +210,7 @@ $quick-jump-default-settings: (
   .empty-message {
     height: quick-jump-settings(bar, height);
     line-height: quick-jump-settings(bar, height);
-    padding-left: $column-gutter + rem-calc(quick-jump-settings(bar, icon-size));
+    padding-left: $column-gutter + quick-jump-settings(bar, icon-size);
   }
 }
 

--- a/components/_quick-jump.scss
+++ b/components/_quick-jump.scss
@@ -1,0 +1,257 @@
+$include-html-paint-quick-jump: true !default;
+
+$quick-jump-default-settings: (
+  bar: (
+    background-color: #e1e5ea,
+    active-background-color: $white,
+    icon-size: $button-icon-size,
+    height: $layout-sidebar-header-height
+  ),
+  results: (
+    background-color: #f2f2f2,
+    item-height: rem-calc(50)
+  ),
+  actions: (
+    navigation: (
+      change-app: th,
+      add: plus
+    )
+  )
+);
+
+@if global-variable-exists(quick-jump) {
+  $quick-jump: map-merge-settings($quick-jump-default-settings, $quick-jump);
+} @else {
+  $quick-jump: $quick-jump-default-settings;
+}
+
+@function quick-jump-settings($setting, $property: null) {
+  @if $property {
+    @return map-get(map-get($quick-jump, $setting), $property);
+  } @else {
+    @return map-get($quick-jump, $setting);
+  }
+}
+
+@mixin quick-jump($overlay: true) {
+  @if $overlay {
+    @include overlay;
+  }
+
+  > .bar {
+    background-color: quick-jump-settings(bar, background-color);
+    display: block;
+    height: quick-jump-settings(bar, height);
+    line-height: quick-jump-settings(bar, height);
+    padding: 0 $column-gutter / 2;
+    position: relative;
+    width: 100%;
+
+    > div,
+    > .icon {
+      @include single-transition(all, 150ms, linear);
+
+      border-radius: $global-rounded;
+      color: $primary-color;
+      height: quick-jump-settings(bar, icon-size);
+      overflow: hidden;
+      position: absolute;
+      text-align: center;
+      top: (quick-jump-settings(bar, height) - quick-jump-settings(bar, icon-size)) / 2;
+      width: quick-jump-settings(bar, icon-size);
+
+      i {
+        @include icon(search);
+
+        display: block;
+        line-height: quick-jump-settings(bar, icon-size);
+      }
+    }
+
+    input {
+      $icon-size: quick-jump-settings(bar, icon-size);
+      $input-left-padding: $icon-size * 1.15;
+
+      @include single-transition(all, 150ms, linear);
+
+      background-color: transparent;
+      border: 0;
+      box-shadow: none;
+      display: inline-block;
+      margin: 0;
+      text-indent: $input-left-padding;
+      width: 100%;
+    }
+  }
+
+  &.active {
+    > .bar {
+      background-color: quick-jump-settings(bar, active-background-color);
+      border-bottom: 1px solid quick-jump-settings(bar, background-color);
+
+      > div,
+      > .icon {
+        background-color: $primary-color;
+        color: quick-jump-settings(bar, active-background-color);
+      }
+    }
+  }
+
+  &.loading {
+    .results .content {
+      opacity: .7;
+    }
+  }
+}
+
+@mixin quick-jump-actions {
+  $quick-jump-actions: quick-jump-settings(actions);
+
+  @each $action-group, $actions in $quick-jump-actions {
+    .#{$action-group}-actions {
+      @each $action, $icon in $actions {
+        .#{$action} {
+          @include button-icon($icon);
+        }
+      }
+    }
+  }
+}
+
+%quick-jump-actions-section {
+  $actions-button-size: $button-icon-size;
+
+  padding: 0 $column-gutter / 2;
+  position: absolute;
+  right: 0;
+  text-align: right;
+  top: (quick-jump-settings(bar, height) - $actions-button-size) / 2;
+
+  .close > button {
+    @include icon(times-circle);
+
+    background-color: transparent;
+    border: 0;
+    margin-bottom: 0;
+    min-height: $actions-button-size;
+  }
+
+  .content {
+    @include quick-jump-actions;
+
+    ul {
+      white-space: nowrap;
+
+      > li {
+        display: inline-block;
+      }
+    }
+  }
+}
+
+%quick-jump-results {
+  $background-color: quick-jump-settings(results, background-color);
+
+  @include single-transition(opacity, 150ms, linear);
+
+  background-color: $background-color;
+  position: relative;
+  width: 100%;
+
+  section {
+    @extend %grid-row;
+
+    padding-bottom: $column-gutter / 2;
+    padding-top: $column-gutter / 2;
+
+    > .title {
+      @extend .hide-for-small-only;
+      @extend %grid-column-2;
+
+      color: $primary-color;
+      line-height: quick-jump-settings(results, item-height);
+      margin-bottom: 0;
+      margin-top: 0;
+      text-align: right;
+    }
+
+    &:nth-of-type(even) {
+      background-color: darken($background-color, 3%);
+    }
+
+    ul {
+      @extend %grid-column-small-12;
+      @extend %grid-column-medium-10;
+      @extend .no-bullet;
+
+      margin-bottom: 0;
+    }
+
+    li {
+      line-height: quick-jump-settings(results, item-height);
+    }
+
+    article {
+      @extend %grid-column-12;
+
+      cursor: pointer;
+
+      &:hover {
+        background-color: lighten($background-color, 3%);
+      }
+
+      .title {
+        color: $body-font-color;
+        line-height: quick-jump-settings(results, item-height);
+      }
+    }
+  }
+
+  .empty-message {
+    height: quick-jump-settings(bar, height);
+    line-height: quick-jump-settings(bar, height);
+    padding-left: $column-gutter + rem-calc(quick-jump-settings(bar, icon-size));
+  }
+}
+
+%quick-jump-result {
+  .title,
+  .details {
+    line-height: quick-jump-settings(results, item-height);
+  }
+
+  .title {
+    @extend %grid-column-small-12;
+    @extend %grid-column-large-4;
+
+    font-size: $base-font-size;
+    margin: 0;
+  }
+
+  .details {
+    @extend %grid-column-small-12;
+    @extend %grid-column-large-8;
+
+    color: $small-font-color;
+  }
+}
+
+@include exports('paint-quick-jump') {
+  @if $include-html-paint-quick-jump {
+    .quick-jump {
+      @include quick-jump;
+
+      .actions {
+        @extend %quick-jump-actions-section;
+      }
+
+      .results {
+        @extend %quick-jump-results;
+
+        .result {
+          @extend %quick-jump-result;
+        }
+      }
+    }
+  }
+}

--- a/components/_quick-jump.scss
+++ b/components/_quick-jump.scss
@@ -5,7 +5,7 @@ $quick-jump-default-settings: (
     background-color: #e1e5ea,
     active-background-color: $white,
     icon-size: rem-calc($button-icon-size),
-    height: $layout-sidebar-header-height
+    height: rem-calc($layout-sidebar-header-height)
   ),
   results: (
     background-color: #f2f2f2,

--- a/components/_side-panel.scss
+++ b/components/_side-panel.scss
@@ -43,19 +43,7 @@ $include-html-paint-side-panel: true !default;
 }
 
 @mixin side-panel {
-  @include single-transition(background-color, 150ms, linear);
-
-  bottom: 0;
-  left: 0;
-  overflow: hidden;
-  position: fixed;
-  right: 0;
-  top: 0;
-  z-index: 200;
-
-  &.active {
-    background-color: $global-overlay-background-color;
-  }
+  @include overlay($position: fixed, $z-index: 200);
 
   > div {
     @include single-transition(opacity, 150ms, linear);

--- a/globals/_mixins.scss
+++ b/globals/_mixins.scss
@@ -3,3 +3,25 @@
   box-shadow: 0 0 0 1px $color, 0 0 0 1px $white inset;
   padding: 1px;
 }
+
+@mixin overlay($position: absolute, $z-index: 100) {
+  @include single-transition(background-color, 150ms, linear);
+
+  bottom: 0;
+  left: 0;
+  overflow-y: auto;
+  pointer-events: none;
+  position: $position;
+  right: 0;
+  top: 0;
+  z-index: $z-index;
+
+  > * {
+    pointer-events: all;
+  }
+
+  &.active {
+    background-color: $global-overlay-background-color;
+    pointer-events: all;
+  }
+}

--- a/paint.scss
+++ b/paint.scss
@@ -20,3 +20,4 @@
 @import 'components/vertical-align';
 @import 'components/form';
 @import 'components/dropdown';
+@import 'components/quick-jump';


### PR DESCRIPTION
* Extracts the overlay styles into a separate mixin and reuse it for both side panel and quick jump
* Implements the quick-jump components with dynamic actions, similar to the side panel.
* Keeps the content structure from phoenix and refactor when we get a custom behaviour from other apps