### PR TITLE
Quick Jump small improvements

### DIFF
--- a/components/_quick-jump.scss
+++ b/components/_quick-jump.scss
@@ -154,11 +154,7 @@ $quick-jump-default-settings: (
     @include quick-jump-actions;
 
     ul {
-      white-space: nowrap;
-
-      > li {
-        display: inline-block;
-      }
+      @extend %button-group;
     }
   }
 }

--- a/components/_quick-jump.scss
+++ b/components/_quick-jump.scss
@@ -95,6 +95,16 @@ $quick-jump-default-settings: (
         color: quick-jump-settings(bar, active-background-color);
       }
     }
+
+    > .actions {
+      .content {
+        display: none;
+      }
+
+      .close {
+        display: block;
+      }
+    }
   }
 
   &.loading {
@@ -127,13 +137,17 @@ $quick-jump-default-settings: (
   text-align: right;
   top: (quick-jump-settings(bar, height) - $actions-button-size) / 2;
 
-  .close > button {
-    @include icon(times-circle);
+  .close {
+    display: none;
 
-    background-color: transparent;
-    border: 0;
-    margin-bottom: 0;
-    min-height: $actions-button-size;
+    > button {
+      @include icon(times-circle);
+
+      background-color: transparent;
+      border: 0;
+      margin-bottom: 0;
+      min-height: $actions-button-size;
+    }
   }
 
   .content {


### PR DESCRIPTION
In Phoenix we currently hide/show quick-jump actions / close button in the controller.
Other apps might not use that and this PR allows toggling the display of actions using CSS.

It also adds button groups to the custom actions to make them consistent with the side panel approach.