### PR TITLE
Sidebar Loading State

### DIFF
--- a/components/_layout.scss
+++ b/components/_layout.scss
@@ -87,6 +87,7 @@ $include-html-paint-layout: true !default;
         height: $layout-sidebar-header-height;
         line-height: $layout-sidebar-header-height;
         padding: 0 $layout-sidebar-nav-padding;
+        position: relative;
 
         img {
           @include single-transition(padding, 150ms, linear);
@@ -102,6 +103,10 @@ $include-html-paint-layout: true !default;
           display: inline-block;
           -webkit-font-smoothing: $body-font-smoothing;
           margin: 0;
+        }
+
+        .logo {
+          @extend %header-logo;
         }
       }
     }

--- a/components/_sidebar-loading-logo.scss
+++ b/components/_sidebar-loading-logo.scss
@@ -1,0 +1,71 @@
+$sidebar-loading-logo-size: 34px;
+$sidebar-loading-logo-loader-color: $layout-sidebar-nav-text-color;
+
+@keyframes sidebar-loading-ring-animation {
+  0% {
+    transform: rotate(0deg);
+  }
+
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+%header-logo {
+  position: relative;
+  width: $sidebar-loading-logo-size;
+  height: $sidebar-loading-logo-size;
+  float: left;
+  margin-top: ($layout-sidebar-header-height - $sidebar-loading-logo-size) / 2;
+  margin-right: ($layout-sidebar-header-height - $sidebar-loading-logo-size) / 2;
+
+  img {
+    position: absolute;
+    margin: 15% !important;
+    height: 70%;
+    transform-origin: 50% 50%;
+    transition:
+      width .2s ease-out,
+      height .2s ease-out,
+      margin .2s ease-in-out;
+  }
+
+  > span {
+    position: absolute;
+    display: block;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    border-radius: 50%;
+    box-shadow: none;
+    transition:
+      box-shadow .4s ease-in-out;
+  }
+
+  &.loading {
+    > span {
+      box-shadow: 0 2px 0 0 $sidebar-loading-logo-loader-color;
+      animation: sidebar-loading-ring-animation .7s linear infinite;
+    }
+
+    img {
+      margin: 25% !important;
+      height: 50%;
+    }
+  }
+}
+
+.application {
+  .sidebar > header {
+    position: relative;
+
+    .logo {
+      @extend %header-logo;
+    }
+  }
+
+  main > .content > div {
+    margin: 0 $column-gutter;
+  }
+}

--- a/components/_sidebar-loading-logo.scss
+++ b/components/_sidebar-loading-logo.scss
@@ -12,60 +12,46 @@ $sidebar-loading-logo-loader-color: $layout-sidebar-nav-text-color;
 }
 
 %header-logo {
+  float: left;
+  height: $sidebar-loading-logo-size;
+  margin-right: ($layout-sidebar-header-height - $sidebar-loading-logo-size) / 2;
+  margin-top: ($layout-sidebar-header-height - $sidebar-loading-logo-size) / 2;
   position: relative;
   width: $sidebar-loading-logo-size;
-  height: $sidebar-loading-logo-size;
-  float: left;
-  margin-top: ($layout-sidebar-header-height - $sidebar-loading-logo-size) / 2;
-  margin-right: ($layout-sidebar-header-height - $sidebar-loading-logo-size) / 2;
 
   img {
-    position: absolute;
-    margin: 15% !important;
     height: 70%;
+    margin: 15% !important;
+    position: absolute;
     transform-origin: 50% 50%;
-    transition:
-      width .2s ease-out,
+    transition: 
       height .2s ease-out,
-      margin .2s ease-in-out;
+      margin .2s ease-in-out,
+      width .2s ease-out;
   }
 
   > span {
-    position: absolute;
-    display: block;
-    width: 100%;
-    height: 100%;
-    top: 0;
-    left: 0;
     border-radius: 50%;
     box-shadow: none;
-    transition:
+    display: block;
+    height: 100%;
+    left: 0;
+    position: absolute;
+    top: 0;
+    transition: 
       box-shadow .4s ease-in-out;
+    width: 100%;
   }
 
   &.loading {
     > span {
-      box-shadow: 0 2px 0 0 $sidebar-loading-logo-loader-color;
       animation: sidebar-loading-ring-animation .7s linear infinite;
+      box-shadow: 0 2px 0 0 $sidebar-loading-logo-loader-color;
     }
 
     img {
-      margin: 25% !important;
       height: 50%;
+      margin: 25% !important;
     }
-  }
-}
-
-.application {
-  .sidebar > header {
-    position: relative;
-
-    .logo {
-      @extend %header-logo;
-    }
-  }
-
-  main > .content > div {
-    margin: 0 $column-gutter;
   }
 }

--- a/paint.scss
+++ b/paint.scss
@@ -15,6 +15,7 @@
 @import 'components/icon';
 @import 'components/label';
 @import 'components/layout';
+@import 'components/sidebar-loading-logo';
 @import 'components/table';
 @import 'components/progress-bar';
 @import 'components/side-panel';


### PR DESCRIPTION
The Dragon logo is not perfectly centred, so rotating it looks a bit unnatural.
This is an idea for a simple global loading state _(e.g use instead of the rotating logo in Dragon)_

http://cl.ly/3I2K1V2X2b1y

* Works for both collapsed and expanded views
* Just need to add a class 'loading' to the logo