### PR TITLE
Implement a reusable panel component

### DIFF
--- a/components/_flip-panel.scss
+++ b/components/_flip-panel.scss
@@ -1,6 +1,8 @@
+@import 'panel';
+
 $flip-panel-default-settings: (
-  header-height: $h1-font-size + $column-gutter,
-  footer-height: $h1-font-size + $column-gutter / 2,
+  header-height: panel-settings(header-height),
+  footer-height: panel-settings(footer-height),
   icons: (
     back: long-arrow-left,
     forward: long-arrow-right
@@ -71,16 +73,14 @@ $include-html-paint-flip-panel: true !default;
 
   .front,
   .back {
+    @extend %panel-default;
+
     @if $min-height {
       position: absolute;
     } @else {
       position: relative;
     }
 
-    backface-visibility: hidden;
-    background-color: $white;
-    border: 1px solid $global-section-border-color;
-    border-radius: $global-radius;
     bottom: 0;
     left: 0;
     overflow: hidden;
@@ -90,30 +90,6 @@ $include-html-paint-flip-panel: true !default;
     transition: 
       transform flip-panel-settings(transition-settings),
       box-shadow flip-panel-settings(transition-settings);
-
-    > header,
-    > footer {
-      background-color: lighten($global-section-border-color, 5%);
-
-      a {
-        font-weight: $font-weight-bold;
-      }
-
-      i {
-        margin-right: $column-gutter / 4;
-      }
-    }
-
-    > header {
-      h1 {
-        color: $small-font-color;
-        font-size: $h4-font-size;
-        font-weight: $font-weight-bold;
-        line-height: flip-panel-settings(header-height);
-        margin: 0;
-        padding: 0 $column-gutter / 2;
-      }
-    }
 
     > footer {
       @if $min-height {
@@ -143,7 +119,7 @@ $include-html-paint-flip-panel: true !default;
   }
 
   .front {
-    box-shadow: 0 1px 3px rgba(0, 0, 0, .025);
+    box-shadow: 0 2px 1px $global-section-border-color;
     transform: rotateX(0deg) rotateY(0deg);
     z-index: 300;
 
@@ -157,6 +133,8 @@ $include-html-paint-flip-panel: true !default;
   }
 
   .back {
+    @include panel-background($white);
+
     position: absolute;
     transform: rotateY(-180deg);
     z-index: 200;
@@ -171,7 +149,7 @@ $include-html-paint-flip-panel: true !default;
   &.flipped {
     .front,
     .back {
-      box-shadow: 0 5px 10px rgba(0, 0, 0, .075);
+      box-shadow: 0 5px 5px rgba(0, 0, 0, .075);
     }
 
     .front {

--- a/components/_flip-panel.scss
+++ b/components/_flip-panel.scss
@@ -119,7 +119,6 @@ $include-html-paint-flip-panel: true !default;
   }
 
   .front {
-    box-shadow: 0 2px 1px $global-section-border-color;
     transform: rotateX(0deg) rotateY(0deg);
     z-index: 300;
 

--- a/components/_panel.scss
+++ b/components/_panel.scss
@@ -64,10 +64,10 @@ $include-html-paint-panel: true !default;
     h1 {
       font-size: $base-font-size;
       font-weight: $font-weight-bold;
+      letter-spacing: 0;
       line-height: panel-settings(header-height);
       margin: 0;
       padding: 0 $column-gutter / 2;
-      letter-spacing: 0;
     }
   }
 }

--- a/components/_panel.scss
+++ b/components/_panel.scss
@@ -62,11 +62,12 @@ $include-html-paint-panel: true !default;
 
   > header {
     h1 {
-      font-size: $h4-font-size;
+      font-size: $base-font-size;
       font-weight: $font-weight-bold;
       line-height: panel-settings(header-height);
       margin: 0;
       padding: 0 $column-gutter / 2;
+      letter-spacing: 0;
     }
   }
 }

--- a/components/_panel.scss
+++ b/components/_panel.scss
@@ -1,0 +1,87 @@
+$panel-default-settings: (
+  header-height: $h1-font-size + $column-gutter,
+  footer-height: $h1-font-size + $column-gutter / 2,
+  styles: (
+    default: lighten($global-section-border-color, 5%),
+    primary: $primary-color,
+    widget: $anchor-font-color
+  ),
+);
+
+@if global-variable-exists(panel) {
+  $panel: map-merge-settings($panel-default-settings, $panel);
+} @else {
+  $panel: $panel-default-settings;
+}
+
+$include-html-paint-panel: true !default;
+
+@function panel-settings($setting, $property: null) {
+  @if $property {
+    @return map-get(map-get($panel, $setting), $property),
+  } @else {
+    @return map-get($panel, $setting)
+  }
+}
+
+@mixin panel-background(
+  $background-color: lighten($global-section-border-color, 5%)
+) {
+  $dark-background-color: desaturate(adjust-hue($background-color, 10%), 15%);
+  $light-background-color: saturate(adjust-hue($background-color, 10%), 15%);
+
+  > header {
+    background: linear-gradient(to right, $dark-background-color, $background-color);
+
+    h1 {
+      color: contrast($background-color);
+    }
+  }
+
+  > footer {
+    background-color: lighten($global-section-border-color, 5%);
+  }
+}
+
+%panel {
+  backface-visibility: hidden;
+  background-color: $white;
+  border: 1px solid $global-section-border-color;
+  border-radius: $global-radius;
+
+  > header,
+  > footer {
+    a {
+      font-weight: $font-weight-bold;
+    }
+
+    i {
+      margin-right: $column-gutter / 4;
+    }
+  }
+
+  > header {
+    h1 {
+      font-size: $h4-font-size;
+      font-weight: $font-weight-bold;
+      line-height: panel-settings(header-height);
+      margin: 0;
+      padding: 0 $column-gutter / 2;
+    }
+  }
+}
+
+@mixin panel-placeholders(
+  $styles: panel-settings(styles)
+) {
+  @each $style, $background-color in $styles {
+    %panel-#{$style} {
+      @extend %panel;
+      @include panel-background($background-color);
+    }
+  }
+}
+
+@include exports('paint-panel') {
+  @include panel-placeholders;
+}

--- a/components/_panel.scss
+++ b/components/_panel.scss
@@ -48,6 +48,7 @@ $include-html-paint-panel: true !default;
   background-color: $white;
   border: 1px solid $global-section-border-color;
   border-radius: $global-radius;
+  box-shadow: 0 2px 1px $global-section-border-color;
 
   > header,
   > footer {
@@ -61,6 +62,8 @@ $include-html-paint-panel: true !default;
   }
 
   > header {
+    border-radius: $global-radius $global-radius 0 0;
+
     h1 {
       font-size: $base-font-size;
       font-weight: $font-weight-bold;

--- a/globals/_settings.scss
+++ b/globals/_settings.scss
@@ -7,7 +7,7 @@ $include-html-tooltip-classes: true;
 $icon-font-folder-path: '/assets/fonts' !default;
 $fa-font-path: $icon-font-folder-path;
 
-$global-radius: 6px !default;
+$global-radius: 4px !default;
 $global-section-border-color: #ececec !default;
 $global-overlay-background-color: rgba(0, 0, 0, .45) !default;
 

--- a/paint.scss
+++ b/paint.scss
@@ -22,4 +22,5 @@
 @import 'components/form';
 @import 'components/dropdown';
 @import 'components/quick-jump';
+@import 'components/panel';
 @import 'components/flip-panel';


### PR DESCRIPTION
The widgets and panels _(e.g flip panels)_ share the same styles.
This PR extracts those styles into a separate component that can now be reused and themed.

As a bonus, we've added a contrast function that would make the panel heading text light or dark depending on the brightness of the background colour.

