### PR TITLE
Include a notifications wrapper placeholder

### DIFF
--- a/components/_notification.scss
+++ b/components/_notification.scss
@@ -95,10 +95,10 @@ $notification-colors: (
 
 @mixin notifications($position: fixed) {
   @if $position == fixed {
+    left: 0;
     position: fixed;
     right: 0;
     top: 0;
-    left: 0;
     width: 100%;
     z-index: 1000;
   } @else {
@@ -111,6 +111,7 @@ $notification-colors: (
   %notifications {
     @include notifications;
   }
+  
   @each $type, $palette in $notification-colors {
     %notification-#{$type} {
       @include notification($palette);

--- a/components/_notification.scss
+++ b/components/_notification.scss
@@ -93,7 +93,24 @@ $notification-colors: (
   }
 }
 
+@mixin notifications($position: fixed) {
+  @if $position == fixed {
+    position: fixed;
+    right: 0;
+    top: 0;
+    left: 0;
+    width: 100%;
+    z-index: 1000;
+  } @else {
+    position: $position;
+    width: 100%;
+  }
+}
+
 @mixin notification-placeholders {
+  %notifications {
+    @include notifications;
+  }
   @each $type, $palette in $notification-colors {
     %notification-#{$type} {
       @include notification($palette);

--- a/components/_notification.scss
+++ b/components/_notification.scss
@@ -111,7 +111,7 @@ $notification-colors: (
   %notifications {
     @include notifications;
   }
-  
+
   @each $type, $palette in $notification-colors {
     %notification-#{$type} {
       @include notification($palette);


### PR DESCRIPTION
This allows adding notifications inside a wrapper that extends `%notifications`.
For different positioning, there is a `notifications` mixin that accepts `$position: fixed / relative / absolute / static` as param.