### PR TITLE
Scale side panel drawer size

### DIFF
--- a/components/_side-panel.scss
+++ b/components/_side-panel.scss
@@ -56,16 +56,12 @@ $include-html-paint-side-panel: true !default;
   }
 
   @if $scaled {
-    $transform-percentage: -100%;
-  } @else {
-    $transform-percentage: -100% * $ratio;
-  }
-
-  @if $scaled {
     $width: "calc(#{$width} * #{$ratio})";
     $drawer-width: $width;
+    $main-translation: -100%;
   } @else {
     $drawer-width: "calc(#{$width} * #{$ratio})";
+    $main-translation: -100% * $ratio;
   }
 
   > .main {
@@ -85,7 +81,7 @@ $include-html-paint-side-panel: true !default;
       // Animating the width of the drawer seems more natural. However, we must
       // use percentages otherwise the transform is wonky (not fluid).
       > .main {
-        transform: translate($transform-percentage, 0);
+        transform: translate($main-translation, 0);
       }
 
       > .drawer {

--- a/components/_side-panel.scss
+++ b/components/_side-panel.scss
@@ -1,3 +1,8 @@
+// Variables are needed here since libsass cannot currently multiply values
+// fetched via map-get. http://git.io/vtC5i
+$scaled-ratio-small: 1;
+$scaled-ratio-large: .5;
+
 $side-panel-default-settings: (
   size: (
     small: 100%,
@@ -5,14 +10,6 @@ $side-panel-default-settings: (
     large: 75em,
     xlarge: 90em,
     xxlarge: 120em
-  ),
-
-  scaled-ratio: (
-    small: 1,
-    medium: 1,
-    large: .5,
-    xlarge: .5,
-    xxlarge: .5
   ),
 
   actions-bar: (
@@ -51,7 +48,18 @@ $include-html-paint-side-panel: true !default;
 
 @mixin side-panel-size($size: large, $scaled: false) {
   $width: side-panel-settings(size, $size);
-  $ratio: side-panel-settings(scaled-ratio, $size);
+
+  @if ($size == small or $size == medium) {
+    $ratio: $scaled-ratio-small;
+  } @else {
+    $ratio: $scaled-ratio-large;
+  }
+
+  @if $scaled {
+    $transform-percentage: -100%;
+  } @else {
+    $transform-percentage: -100% * $ratio;
+  }
 
   @if $scaled {
     $width: "calc(#{$width} * #{$ratio})";
@@ -74,8 +82,10 @@ $include-html-paint-side-panel: true !default;
     }
 
     &.drawer-active {
+      // Animating the width of the drawer seems more natural. However, we must
+      // use percentages otherwise the transform is wonky (not fluid).
       > .main {
-        transform: translate(#{-$drawer-width}, 0);
+        transform: translate($transform-percentage, 0);
       }
 
       > .drawer {
@@ -86,12 +96,6 @@ $include-html-paint-side-panel: true !default;
 }
 
 @mixin side-panel($overlay: true, $scaled: false) {
-  @if $scaled {
-    $ratio: 1;
-  } @else {
-    $ratio: 0.5;
-  }
-
   @if $overlay {
     @include overlay($position: fixed, $z-index: 200);
   }

--- a/components/_side-panel.scss
+++ b/components/_side-panel.scss
@@ -51,18 +51,21 @@ $include-html-paint-side-panel: true !default;
 
 @mixin side-panel-size($size: large, $scaled: false) {
   $width: side-panel-settings(size, $size);
+  $ratio: side-panel-settings(scaled-ratio, $size);
 
   @if $scaled {
-    $ratio: side-panel-settings(scaled-ratio, $size);
     $width: "calc(#{$width} * #{$ratio})";
+    $drawer-width: $width;
+  } @else {
+    $drawer-width: "calc(#{$width} * #{$ratio})";
   }
 
-  width: #{$width};
-}
+  > .main {
+    width: #{$width};
+  }
 
-@mixin side-panel($overlay: true, $scaled: false) {
-  @if $overlay {
-    @include overlay($position: fixed, $z-index: 200);
+  > .drawer {
+    width: #{$drawer-width};
   }
 
   &.active {
@@ -72,14 +75,28 @@ $include-html-paint-side-panel: true !default;
 
     &.drawer-active {
       > .main {
-        transform: translate(-100%, 0);
+        transform: translate(#{-$drawer-width}, 0);
       }
 
       > .drawer {
         transform: translate(0, 0);
       }
     }
+  }
+}
 
+@mixin side-panel($overlay: true, $scaled: false) {
+  @if $scaled {
+    $ratio: 1;
+  } @else {
+    $ratio: 0.5;
+  }
+
+  @if $overlay {
+    @include overlay($position: fixed, $z-index: 200);
+  }
+
+  &.active {
     > .main,
     > .drawer {
       > header {
@@ -143,26 +160,26 @@ $include-html-paint-side-panel: true !default;
         width: 100%;
       }
     }
+  }
 
-    @media #{$small-only} {
-      @include side-panel-size(small, $scaled);
-    }
+  @media #{$small-only} {
+    @include side-panel-size(small, $scaled);
+  }
 
-    @media #{$medium-only} {
-      @include side-panel-size(medium, $scaled);
-    }
+  @media #{$medium-only} {
+    @include side-panel-size(medium, $scaled);
+  }
 
-    @media #{$large-only} {
-      @include side-panel-size(large, $scaled);
-    }
+  @media #{$large-only} {
+    @include side-panel-size(large, $scaled);
+  }
 
-    @media #{$xlarge-only} {
-      @include side-panel-size(xlarge, $scaled);
-    }
+  @media #{$xlarge-only} {
+    @include side-panel-size(xlarge, $scaled);
+  }
 
-    @media #{$xxlarge-up} {
-      @include side-panel-size(xxlarge, $scaled);
-    }
+  @media #{$xxlarge-up} {
+    @include side-panel-size(xxlarge, $scaled);
   }
 
   > .main {


### PR DESCRIPTION
## What's up??
Currently the side panel drawer is configured to be the same width as the main side panel. For larger side panels, this is not the desired sizing as the nested side panel ends up being too large.

## What this does
This changes the side panel drawer sizing to be calculated based upon a ratio of the main side panel size.

@deioo, can you review?