### PR TITLE
Change the color of every childer of the panel header

### DIFF
--- a/components/_panel.scss
+++ b/components/_panel.scss
@@ -33,7 +33,7 @@ $include-html-paint-panel: true !default;
   > header {
     background: linear-gradient(to right, $dark-background-color, $background-color);
 
-    h1 {
+    * {
       color: contrast($background-color);
     }
   }


### PR DESCRIPTION
The reason is that we might have other elements in the header and we want them to always contrast with the background.