### PR TITLE
Implement an AppSwitcher component

### DIFF
--- a/components/_app-switcher.scss
+++ b/components/_app-switcher.scss
@@ -1,0 +1,95 @@
+$app-switcher-default-settings: (
+  icon-width: 48px,
+
+  apps: (
+    pistachio: primary,
+    phoenix: link,
+    reporting: secondary,
+    dragon: success
+  )
+);
+
+@if global-variable-exists(app-switcher) {
+  $app-switcher: map-merge-settings($app-switcher-default-settings, $app-switcher);
+} @else {
+  $app-switcher: $app-switcher-default-settings;
+}
+
+@function app-switcher-settings($setting, $property: null) {
+  @if $property {
+    @return map-get(map-get($app-switcher, $setting), $property),
+  } @else {
+    @return map-get($app-switcher, $setting)
+  }
+}
+
+@mixin app-switcher-icon(
+  $background-color: primary,
+  $width: app-switcher-settings(icon-width)
+) {
+  $background-color: color($background-color);
+  $dark-background-color: saturate($background-color, 10%);
+
+  background: linear-gradient(to right, $dark-background-color, $background-color);
+  border-radius: $global-radius;
+  display: block;
+  height: $width;
+  margin: $column-gutter auto $column-gutter / 2;
+  width: $width;
+}
+
+@mixin app-switcher-icons {
+  @each $app, $background-color in app-switcher-settings(apps) {
+    &.#{$app} {
+      > a > i {
+        @include app-switcher-icon($background-color);
+      }
+    }
+  }
+}
+
+%app-switcher-label {
+  color: color(text, small);
+  display: block;
+  font-size: $small-font-size;
+  font-weight: $font-weight-bold;
+  margin-bottom: $column-gutter / 2;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+
+@include exports('paint-app-switcher') {
+  %app-switcher-list {
+    > ul {
+      @extend %grid-row;
+
+      > li {
+        @extend %grid-column-4;
+        @include app-switcher-icons;
+
+        text-align: center;
+
+        > span {
+          @extend %app-switcher-label;            
+        }
+      }
+    }    
+  }
+  
+  .app-switcher {
+    @include modal($use-content-size: true);
+
+    > div {
+      > header {
+        text-align: center;
+      }
+
+      > .content {
+        @extend %app-switcher-list;
+
+        padding: 0 $column-gutter;
+      }
+    }
+  }
+}

--- a/paint.scss
+++ b/paint.scss
@@ -27,3 +27,4 @@
 @import 'components/panel';
 @import 'components/flip-panel';
 @import 'components/modal';
+@import 'components/app-switcher';


### PR DESCRIPTION
Basic styles for a reusable AppSwitcher component

Includes:
* Customizable app names and colours
* Separate mixins and placeholders for different selectors
* Default Css classes generated for easy integration

**Preview**
<img width="816" alt="screen_shot_2015-07-28_at_17_14_00" src="https://cloud.githubusercontent.com/assets/1321353/8936836/81189aae-354c-11e5-847e-291e80da1623.png">
