### PR TITLE
Fix SassRails Compiler Errors

### DIFF
--- a/components/_app-switcher.scss
+++ b/components/_app-switcher.scss
@@ -1,3 +1,4 @@
+$app-switcher: () !default;
 $app-switcher-default-settings: (
   icon-width: 48px,
 
@@ -9,11 +10,7 @@ $app-switcher-default-settings: (
   )
 );
 
-@if global-variable-exists(app-switcher) {
-  $app-switcher: map-merge-settings($app-switcher-default-settings, $app-switcher);
-} @else {
-  $app-switcher: $app-switcher-default-settings;
-}
+$app-switcher: map-merge-settings($app-switcher-default-settings, $app-switcher);
 
 @function app-switcher-settings($setting, $property: null) {
   @if $property {

--- a/components/_color.scss
+++ b/components/_color.scss
@@ -1,3 +1,4 @@
+$colors: () !default;
 $colors-default-settings: (
   text: (
     base: #222222,
@@ -72,11 +73,7 @@ $colors-default-settings: (
   )
 );
 
-@if global-variable-exists(colors) {
-  $colors: map-merge-settings($colors-default-settings, $colors);
-} @else {
-  $colors: $colors-default-settings;
-}
+$colors: map-merge-settings($colors-default-settings, $colors);
 
 @function color($color, $variant: base) {
   $color: map-get($colors, $color);

--- a/components/_flip-panel.scss
+++ b/components/_flip-panel.scss
@@ -1,5 +1,6 @@
 @import 'panel';
 
+$flip-panel: () !default;
 $flip-panel-default-settings: (
   header-height: panel-settings(header-height),
   footer-height: panel-settings(footer-height),
@@ -10,11 +11,7 @@ $flip-panel-default-settings: (
   transition-settings: .3s ease-in-out
 );
 
-@if global-variable-exists(flip-panel) {
-  $flip-panel: map-merge-settings($flip-panel-default-settings, $flip-panel);
-} @else {
-  $flip-panel: $flip-panel-default-settings;
-}
+$flip-panel: map-merge-settings($flip-panel-default-settings, $flip-panel);
 
 $include-html-paint-flip-panel: true !default;
 

--- a/components/_modal.scss
+++ b/components/_modal.scss
@@ -1,3 +1,4 @@
+$modal: () !default;
 $modal-default-settings: (
   size: (
     small: 98%,
@@ -8,11 +9,7 @@ $modal-default-settings: (
   )
 );
 
-@if global-variable-exists(modal) {
-  $modal: map-merge-settings($modal-default-settings, $modal);
-} @else {
-  $modal: $modal-default-settings;
-}
+$modal: map-merge-settings($modal-default-settings, $modal);
 
 $include-html-paint-modal: true !default;
 

--- a/components/_panel.scss
+++ b/components/_panel.scss
@@ -1,3 +1,4 @@
+$panel: () !default;
 $panel-default-settings: (
   header-height: $h1-font-size + $column-gutter,
   footer-height: $h1-font-size + $column-gutter / 2,
@@ -8,11 +9,7 @@ $panel-default-settings: (
   ),
 );
 
-@if global-variable-exists(panel) {
-  $panel: map-merge-settings($panel-default-settings, $panel);
-} @else {
-  $panel: $panel-default-settings;
-}
+$panel: map-merge-settings($panel-default-settings, $panel);
 
 $include-html-paint-panel: true !default;
 

--- a/components/_quick-jump.scss
+++ b/components/_quick-jump.scss
@@ -1,5 +1,4 @@
-$include-html-paint-quick-jump: true !default;
-
+$quick-jump: () !default;
 $quick-jump-default-settings: (
   bar: (
     background-color: #e1e5ea,
@@ -19,11 +18,9 @@ $quick-jump-default-settings: (
   )
 );
 
-@if global-variable-exists(quick-jump) {
-  $quick-jump: map-merge-settings($quick-jump-default-settings, $quick-jump);
-} @else {
-  $quick-jump: $quick-jump-default-settings;
-}
+$quick-jump: map-merge-settings($quick-jump-default-settings, $quick-jump);
+
+$include-html-paint-quick-jump: true !default;
 
 @function quick-jump-settings($setting, $property: null) {
   @if $property {

--- a/components/_side-panel.scss
+++ b/components/_side-panel.scss
@@ -45,20 +45,18 @@ $include-html-paint-side-panel: true !default;
 
 @mixin side-panel-size($size: large, $scaled: false) {
   $width: side-panel-settings(size, $size);
+  $ratio: $scaled-ratio-large;
+  $main-translation: -100% * $ratio;
+  $drawer-width: "calc(#{$width} * #{$ratio})";
 
   @if ($size == small or $size == medium) {
     $ratio: $scaled-ratio-small;
-  } @else {
-    $ratio: $scaled-ratio-large;
   }
 
   @if $scaled {
     $width: "calc(#{$width} * #{$ratio})";
     $drawer-width: $width;
     $main-translation: -100%;
-  } @else {
-    $drawer-width: "calc(#{$width} * #{$ratio})";
-    $main-translation: -100% * $ratio;
   }
 
   > .main {

--- a/components/_side-panel.scss
+++ b/components/_side-panel.scss
@@ -1,8 +1,4 @@
-// Variables are needed here since libsass cannot currently multiply values
-// fetched via map-get. http://git.io/vtC5i
-$scaled-ratio-small: 1;
-$scaled-ratio-large: .5;
-
+$side-panel: () !default;
 $side-panel-default-settings: (
   size: (
     small: 100%,
@@ -30,11 +26,12 @@ $side-panel-default-settings: (
   )
 );
 
-@if global-variable-exists(side-panel) {
-  $side-panel: map-merge-settings($side-panel-default-settings, $side-panel);
-} @else {
-  $side-panel: $side-panel-default-settings;
-}
+$side-panel: map-merge-settings($side-panel-default-settings, $side-panel);
+
+// Variables are needed here since libsass cannot currently multiply values
+// fetched via map-get. http://git.io/vtC5i
+$scaled-ratio-small: 1;
+$scaled-ratio-large: .5;
 
 $include-html-paint-side-panel: true !default;
 

--- a/components/_typography.scss
+++ b/components/_typography.scss
@@ -1,3 +1,4 @@
+$typography: () !default;
 $typography-default-settings: (
   header-tags: (
     h1, h2, h3, h4, h5, h6, blockquote
@@ -6,11 +7,7 @@ $typography-default-settings: (
   condensed-tags: ()
 );
 
-@if global-variable-exists(typography) {
-  $typography: map-merge-settings($typography-default-settings, $typography);
-} @else {
-  $typography: $typography-default-settings;
-}
+$typography: map-merge-settings($typography-default-settings, $typography);
 
 $include-html-paint-typography: true !default;
 

--- a/globals/_functions.scss
+++ b/globals/_functions.scss
@@ -59,10 +59,10 @@
   $dark-text-brightness: brightness($dark);
   $light-text-brightness: brightness($light);
 
+  $output: $dark;
+
   @if abs($color-brightness - $light-text-brightness) > abs($color-brightness - $dark-text-brightness) {
     $output: $light;
-  } @else {
-    $output: $dark;
   }
 
   @return $output;


### PR DESCRIPTION
### Sass Rails Compiler Issues:
* Sass Rails compiler returns an error saying that global component settings maps are not defined, even if the `global-variable-exists` function is used.
* Sass Rails returns an error saying that private variables are undefined, even if they're clearly being set
```scss
  // Not working with SassRails
  @if $something {
    $output: foo;
  } @else {
    $output: bar;
  }

  @return $output;
```
```scss
  // Working with SassRails
  $output: bar;

  @if $something {
    $output: foo;
  } 

  @return $output;
```

**Both above cases are handled properly by LibSass.**

### Solution

Define default empty settings map within each component.