### PR TITLE
Allow passing color codes to the color function

### DIFF
--- a/components/_color.scss
+++ b/components/_color.scss
@@ -76,36 +76,40 @@ $colors-default-settings: (
 $colors: map-merge-settings($colors-default-settings, $colors);
 
 @function color($color, $variant: base) {
-  $color: map-get($colors, $color);
+  $output-color: map-get($colors, $color);
   $adjust: ();
   $is-map: false;
 
-  @if type-of($color) == 'map' {
-    $color: map-get($color, $variant);
+  @if type-of($output-color) == 'map' {
+    $output-color: map-get($output-color, $variant);
     $is-map: true;
   }
 
-  $base: nth($color, 1);
+  $base: nth($output-color, 1);
 
-  @if length($color) > 1 {
-    $adjust: nth($color, 2);
+  @if length($output-color) > 1 {
+    $adjust: nth($output-color, 2);
   }
 
   @if $is-map {
     @if map-has-key($colors, $base) {
-      $color: color($base);
+      $output-color: color($base);
     } @else {
-      $color: $base;
+      $output-color: $base;
     }
 
     @each $function, $value in $adjust {
       @if function-exists($function) {
-        $color: call($function, $color, $value);
+        $output-color: call($function, $output-color, $value);
       } @else {
         @error "Function '#{$function}' in #{$adjust} doesn't exist.";
       }
     }
   }
 
-  @return $color;
+  @if not $output-color {
+    $output-color: $color;
+  }
+
+  @return $output-color;
 }


### PR DESCRIPTION
This allows the use the `color` function with both static colors and palette variations

**E.g.**
`color(#fc0000)` would work now