### PR TITLE
Implement a basic checkbox field

### DIFF
--- a/components/_form.scss
+++ b/components/_form.scss
@@ -122,6 +122,7 @@ $include-html-paint-form: true !default;
   @if $inline {
     width: auto !important;
   }
+  
   min-height: $form-input-height * 2;
 
   label {
@@ -130,9 +131,9 @@ $include-html-paint-form: true !default;
   }
 
   #{$inner-wrapper} {
-    line-height: $form-input-height;
-    float: $float;
     display: inline-block;
+    float: $float;
+    line-height: $form-input-height;
   }
 }
 

--- a/components/_form.scss
+++ b/components/_form.scss
@@ -108,6 +108,34 @@ $include-html-paint-form: true !default;
   }
 }
 
+@mixin form-checkbox($inner-wrapper: '.content', $float: left, $inline: false) {
+  @if ($inner-wrapper == null) {
+    $inner-wrapper: '&';
+  }
+
+  $label-margin-direction: right;
+
+  @if ($float == left) {
+    $label-margin-direction: left;
+  }
+
+  @if $inline {
+    width: auto !important;
+  }
+  min-height: $form-input-height * 2;
+
+  label {
+    display: inline-block;
+    margin-#{$label-margin-direction}: $column-gutter / 2;
+  }
+
+  #{$inner-wrapper} {
+    line-height: $form-input-height;
+    float: $float;
+    display: inline-block;
+  }
+}
+
 @mixin form-select($inner-wrapper: '.content', $inline: false) {
   @if ($inner-wrapper == null) {
     $inner-wrapper: '&';
@@ -707,6 +735,11 @@ $include-html-paint-form: true !default;
 
           input {
             @include form-input;
+          }
+
+          &.form-checkbox,
+          &.form-radio {
+            @include form-checkbox;
           }
 
           &.form-select {


### PR DESCRIPTION
**Usage**

* Add the `.form-checkbox` / `.form-radio` class to a standard `.form-field`
* Include the mixin to a basic `.form-field` element 

E.g
```scss
form-field.inline-custom-checkbox {
  @include form-checkbox($float: none, $inline: true);
}
```

Default checkbox markup follows the standard field format

```haml
.form-field.form-checkbox
  %label
  .content
    %input{ type: 'checkbox' }
```

The `form-checkbox` mixin allows containerless inputs, e.g

```scss
.containerless-checkbox {
  @include form-checkbox($inner-wrapper: null);
}
```
which would allow the following simplified markup to work
```haml
.form-field.containerless-checkbox
  %label Checkbox label
  %input{ type: 'checkbox' }
```