### PR TITLE
Make navigation logo background color customizable

### DIFF
--- a/components/_navigation.scss
+++ b/components/_navigation.scss
@@ -51,7 +51,9 @@ $include-html-paint-navigation: true !default;
   text-transform: uppercase;
 }
 
-@mixin navigation-logo {
+@mixin navigation-logo(
+  $hover-background-color: navigation-settings(topbar, hover-background-color)
+) {
   $logo-padding: (navigation-settings(sidebar, min-width) - navigation-settings(logo-width)) / 2;
 
   background: 
@@ -67,7 +69,7 @@ $include-html-paint-navigation: true !default;
   padding-left: 0;
 
   &:hover {
-    background-color: navigation-settings(topbar, hover-background-color) !important;
+    background-color: $hover-background-color !important;
   }
 
   span {
@@ -159,8 +161,10 @@ $include-html-paint-navigation: true !default;
       }
     }
 
-    .logo {
-      @include navigation-logo;
+    > .logo {
+      @include navigation-logo(
+        $hover-background-color: navigation-settings(topbar, background-color)
+      );
     }
   }
 }
@@ -196,6 +200,10 @@ $include-html-paint-navigation: true !default;
 
     span {
       color: color(white);
+    }
+
+    .logo {
+      @include navigation-logo;
     }
   }
 


### PR DESCRIPTION
* Fix bug where hovering the topbar navigation logo gets the default sidebar inverted background color