### PR TITLE
Stage transform prefix due to non compatible with iOS webkit

### DIFF
--- a/components/_navigation.scss
+++ b/components/_navigation.scss
@@ -369,7 +369,6 @@ $include-html-paint-navigation: true !default;
   overflow: hidden;
   position: fixed;
   top: 0;
-  -webkit-transform: translateX(navigation-settings(height-negative));
   transform: translateX(navigation-settings(height-negative));
   transition: 
     transform navigation-settings(transition-duration),
@@ -484,14 +483,12 @@ $sidebar-full-open: '.part-open:hover';
 #{navigation-settings(sidebar, selector)} {
   &#{$sidebar-full-open},
   &#{$sidebar-part-open} {
-    -webkit-transform: translateX(0);
     transform: translateX(0);
   }
 
   &#{$sidebar-part-open} > footer {
     #{navigation-settings(sidebar-footer, avatar-selector)},
     #{navigation-settings(sidebar-footer, title-selector)} {
-      -webkit-transform: translateY(100px);
       transform: translateY(100px);
       transition: transform $global-transition-duration ease;
       transition-delay: 0s;
@@ -514,7 +511,6 @@ $sidebar-full-open: '.part-open:hover';
     > footer {
       #{navigation-settings(sidebar-footer, avatar-selector)},
       #{navigation-settings(sidebar-footer, title-selector)} {
-        -webkit-transform: translateY(0);
         transform: translateY(0);
         transition-delay: navigation-settings(transition-duration) / 2;
       }
@@ -532,19 +528,16 @@ $sidebar-full-open: '.part-open:hover';
   #{navigation-settings(selector)} {
     .item.with-sidebar:hover, .item.with-sidebar:focus
     #{navigation-settings(sidebar, selector)} {
-      -webkit-transform: translateX(0);
       transform: translateX(0);
     }
 
     #{navigation-settings(sidebar, selector)} {
       &#{$sidebar-part-open} {
-        -webkit-transform: translateX(navigation-settings(height-negative));
         transform: translateX(navigation-settings(height-negative));
       }
 
       &#{$sidebar-full-open} {
         min-width: navigation-settings(sidebar, width);
-        -webkit-transform: translateX(0);
         transform: translateX(0);
         width: 80%;
 

--- a/components/_navigation.scss
+++ b/components/_navigation.scss
@@ -145,7 +145,7 @@ $navigation-default-settings: (
     text-color: #a5a5a5,
     submenu-text-color: darken(#a5a5a5, 20%),
     min-width: 60px,
-    width: 300px
+    width: 280px
   ),
 
   sidebar-footer: (
@@ -369,6 +369,7 @@ $include-html-paint-navigation: true !default;
   overflow: hidden;
   position: fixed;
   top: 0;
+  -webkit-transform: translateX(navigation-settings(height-negative));
   transform: translateX(navigation-settings(height-negative));
   transition: 
     transform navigation-settings(transition-duration),
@@ -401,6 +402,7 @@ $include-html-paint-navigation: true !default;
 
   .scroller {
     left: 0;
+    -webkit-overflow-scrolling: touch;
     overflow-y: scroll;
     position: absolute;
     right: 0;
@@ -482,12 +484,14 @@ $sidebar-full-open: '.part-open:hover';
 #{navigation-settings(sidebar, selector)} {
   &#{$sidebar-full-open},
   &#{$sidebar-part-open} {
+    -webkit-transform: translateX(0);
     transform: translateX(0);
   }
 
   &#{$sidebar-part-open} > footer {
     #{navigation-settings(sidebar-footer, avatar-selector)},
     #{navigation-settings(sidebar-footer, title-selector)} {
+      -webkit-transform: translateY(100px);
       transform: translateY(100px);
       transition: transform $global-transition-duration ease;
       transition-delay: 0s;
@@ -510,6 +514,7 @@ $sidebar-full-open: '.part-open:hover';
     > footer {
       #{navigation-settings(sidebar-footer, avatar-selector)},
       #{navigation-settings(sidebar-footer, title-selector)} {
+        -webkit-transform: translateY(0);
         transform: translateY(0);
         transition-delay: navigation-settings(transition-duration) / 2;
       }
@@ -521,25 +526,27 @@ $sidebar-full-open: '.part-open:hover';
   #{$layout-main-selector} {
     &.with-sidebar {
       margin-left: 0;
-      margin-top: navigation-settings(height);
     }
   }
 
   #{navigation-settings(selector)} {
-    .item.with-sidebar:hover
+    .item.with-sidebar:hover, .item.with-sidebar:focus
     #{navigation-settings(sidebar, selector)} {
+      -webkit-transform: translateX(0);
       transform: translateX(0);
     }
 
     #{navigation-settings(sidebar, selector)} {
       &#{$sidebar-part-open} {
+        -webkit-transform: translateX(navigation-settings(height-negative));
         transform: translateX(navigation-settings(height-negative));
       }
 
       &#{$sidebar-full-open} {
         min-width: navigation-settings(sidebar, width);
+        -webkit-transform: translateX(0);
         transform: translateX(0);
-        width: 100%;
+        width: 80%;
 
         .scroller {
           width: 130%;

--- a/components/_navigation.scss
+++ b/components/_navigation.scss
@@ -526,7 +526,8 @@ $sidebar-full-open: '.part-open:hover';
   }
 
   #{navigation-settings(selector)} {
-    .item.with-sidebar:hover, .item.with-sidebar:focus
+    .item.with-sidebar:hover,
+    .item.with-sidebar:focus
     #{navigation-settings(sidebar, selector)} {
       transform: translateX(0);
     }


### PR DESCRIPTION
 ### The problem:
[transform does not work in ios.](http://stackoverflow.com/questions/27303339/transform-not-working-on-ios)

### The result:
Linting throwing warnings:
<img width="509" alt="screen shot 2015-09-16 at 1 48 24 am" src="https://cloud.githubusercontent.com/assets/497142/9898080/06022868-5c15-11e5-8825-abeaebc62156.png">

These are 3 solutions I can think of
1. Disable throwing warnings for "Avoid vendor prefixes." error or
2. Make each project's responsibility to handle vendor prefixes
3. Make paint auto-prefix it's own components

But would really appreciate @deioo's point of view on solving this issue ?