### PR TITLE
Form multi-checkbox tweaks

### DIFF
--- a/components/_form.scss
+++ b/components/_form.scss
@@ -325,8 +325,8 @@ $include-html-paint-form: true !default;
 
   #{$options} {
     margin: 0;
-    padding-right: 20%;
     padding: 0;
+    padding-right: 20%;
     width: 120%;
   }
 

--- a/components/_form.scss
+++ b/components/_form.scss
@@ -307,9 +307,8 @@ $include-html-paint-form: true !default;
 
 @mixin form-multi-select-options($options, $option, $is-focused-selector) {
   background-color: color(white);
-  border-color: $form-input-border-color;
   border-radius: 0 0 $global-radius $global-radius;
-  border: 1px solid;
+  border: 1px solid $form-input-border-color;
   box-shadow: 0 1px 0 rgba(0, 0, 0, .06);
   box-sizing: border-box;
   display: none;
@@ -350,10 +349,10 @@ $include-html-paint-form: true !default;
       background-color: $form-multi-select-option-focused-background;
       color: $form-multi-select-option-focused-color;
       transition: background .125s ease;
+    }
 
-      &:last-child {
-        margin-bottom: -1px;
-      }
+    &#{$is-focused-selector}::last-child {
+      margin-bottom: -1px;
     }
   }
 }

--- a/components/_form.scss
+++ b/components/_form.scss
@@ -491,6 +491,7 @@ $include-html-paint-form: true !default;
     @include icon($icon);
     
     float: right;
+    font-size: $small-font-size;
     line-height: $form-input-height;
     margin-left: $column-gutter / 2;
   }

--- a/components/_form.scss
+++ b/components/_form.scss
@@ -319,15 +319,18 @@ $include-html-paint-form: true !default;
   -webkit-overflow-scrolling: touch;
   position: absolute;
   top: 100%;
-  width: 100%;
+  max-height: $form-multi-select-options-max-height;
+  min-width: 100%;
+  overflow-x: hidden;
+  overflow-y: auto;
+
   z-index: 1;
 
   #{$options} {
     margin: 0;
-    max-height: $form-multi-select-options-max-height;
-    overflow-x: hidden;
-    overflow-y: auto;
     padding: 0;
+    width: 120%;
+    padding-right: 20%;
   }
 
   #{$option} {
@@ -496,7 +499,11 @@ $include-html-paint-form: true !default;
   }
 }
 
-@mixin form-multi-checkbox-option($is-checked-selector: $is-checked-selector) {
+@mixin form-multi-checkbox-option(
+  $is-checked-selector: $is-checked-selector,
+  $option-whitespace: normal
+) {
+  white-space: $option-whitespace;
   &:before {
     @include icon(square-o);
 
@@ -519,13 +526,14 @@ $include-html-paint-form: true !default;
 @mixin form-multi-checkbox-options(
   $options: $options,
   $option: $option,
+  $option-whitespace: $option-whitespace,
   $is-focused-selector: $is-focused-selector,
   $is-checked-selector: $is-checked-selector
 ) {
   @include form-multi-select-options($options, $option, $is-focused-selector);
 
   #{$option} {
-    @include form-multi-checkbox-option($is-checked-selector);
+    @include form-multi-checkbox-option($is-checked-selector, $option-whitespace);
   }
 }
 
@@ -534,6 +542,7 @@ $include-html-paint-form: true !default;
   $options-selector: '.options-selector',
   $options: '.options',
   $option: '.option',
+  $option-whitespace: nowrap,
   $is-open-selector: '.is-open',
   $has-items-selector: '.has-value',
   $is-focused-selector: '.is-focused',
@@ -576,6 +585,7 @@ $include-html-paint-form: true !default;
     @include form-multi-checkbox-options(
       $options: $options,
       $option: $option,
+      $option-whitespace: $option-whitespace,
       $is-focused-selector: $is-focused-selector,
       $is-checked-selector: $is-checked-selector
     );

--- a/components/_form.scss
+++ b/components/_form.scss
@@ -29,13 +29,13 @@ $form-multi-select-option-color: $form-input-text-color !default;
 $form-multi-select-item-border: 0 !default;
 $form-multi-select-item-background: color(gray, jet) !default;
 $form-multi-select-item-color: color(white) !default;
-$form-multi-select-option-focused-background: color(primary) !default;
-$form-multi-select-option-focused-color: color(white) !default;
+$form-multi-select-option-focused-background: color(border, light) !default;
+$form-multi-select-option-focused-color: color(text) !default;
 $form-multi-select-dropdown-icon: plus !default;
 $form-multi-select-options-max-height: 200px !default;
 
-$form-multi-checkbox-option-checked-background: color(primary);
-$form-multi-checkbox-option-checked-color: color(white);
+$form-multi-checkbox-option-checked-background: color(info, light);
+$form-multi-checkbox-option-checked-color: color(info, dark);
 
 $include-html-paint-form: true !default;
 

--- a/components/_form.scss
+++ b/components/_form.scss
@@ -307,22 +307,21 @@ $include-html-paint-form: true !default;
 
 @mixin form-multi-select-options($options, $option, $is-focused-selector) {
   background-color: color(white);
-  border: 1px solid;
   border-color: $form-input-border-color;
   border-radius: 0 0 $global-radius $global-radius;
+  border: 1px solid;
   box-shadow: 0 1px 0 rgba(0, 0, 0, .06);
   box-sizing: border-box;
   display: none;
   margin-bottom: $column-gutter / 2;
   margin-top: -1px;
   max-height: $form-multi-select-options-max-height;
-  -webkit-overflow-scrolling: touch;
-  position: absolute;
-  top: 100%;
-  max-height: $form-multi-select-options-max-height;
   min-width: 100%;
+  -webkit-overflow-scrolling: touch;
   overflow-x: hidden;
   overflow-y: auto;
+  position: absolute;
+  top: 100%;
 
   z-index: 1;
 
@@ -504,6 +503,7 @@ $include-html-paint-form: true !default;
   $option-whitespace: normal
 ) {
   white-space: $option-whitespace;
+
   &:before {
     @include icon(square-o);
 

--- a/components/_form.scss
+++ b/components/_form.scss
@@ -322,14 +322,13 @@ $include-html-paint-form: true !default;
   overflow-y: auto;
   position: absolute;
   top: 100%;
-
   z-index: 1;
 
   #{$options} {
     margin: 0;
+    padding-right: 20%;
     padding: 0;
     width: 120%;
-    padding-right: 20%;
   }
 
   #{$option} {


### PR DESCRIPTION
* Allow width of the options selector to exceed the parent width
* Moves the scrolling behaviour to the parent block
* Adds a customisable `white-space` _(nowrap by default)_ for the option selector

<img src="http://f.cl.ly/items/2v2M2A1R1r1c442H042Q/Screen%20Recording%202015-09-16%20at%2003.53%20pm.gif" />