### PR TITLE
More button styles

### DIFF
--- a/components/_button.scss
+++ b/components/_button.scss
@@ -108,36 +108,53 @@ $include-html-paint-button: true !default;
   }
 }
 
+/// Solid button styles
+/// @access private 
+
+@mixin button-solid(
+  $bg: color(white),
+  $color: color(primary)
+) {
+  @include button(
+    $bg: $bg,
+    $radius: $global-radius,
+    $bg-hover: $color,
+    $border-color: $color
+  );
+
+  border: 1px solid $color;
+  color: $color;
+  font-size: $small-font-size;
+  font-weight: $font-weight-bold;
+  margin-bottom: 0;
+  padding: $button-base-padding;
+  text-transform: uppercase;
+
+  &:focus {
+    background-color: $bg;
+    color: $color;
+  }
+
+  &:hover {
+    background-color: $color;
+    border-color: $bg;
+    color: $bg;
+  }
+}
+
 /// Generate all button styles placeholders
 /// @access private 
 
 @mixin button-color-placeholders {
   @each $type, $button-color in $button-colors {
     %button-#{$type} {
-      @include button(
-        $bg: color(white),
-        $radius: $global-radius,
-        $bg-hover: $button-color,
-        $border-color: $button-color
-      );
+      @include button-solid($color: $button-color);
+    }
 
-      border: 1px solid $button-color;
-      color: $button-color;
-      font-size: $small-font-size;
-      font-weight: $font-weight-bold;
-      margin-bottom: 0;
-      padding: $button-base-padding;
-      text-transform: uppercase;
+    %button-#{$type}-inverted {
+      @include button-solid($bg: $button-color, $color: contrast($button-color, $dark: color(text)));
 
-      &:focus {
-        background-color: color(white);
-        color: $button-color;
-      }
-
-      &:hover {
-        background-color: $button-color;
-        color: color(white);
-      }
+      border-color: transparent;
     }
   }
 }

--- a/components/_button.scss
+++ b/components/_button.scss
@@ -183,6 +183,13 @@ $include-html-paint-button: true !default;
   padding: 0 $button-base-padding * 2;
 }
 
+/// Rounded button style
+/// @require {placeholder} button
+
+%button-rounded {
+  border-radius: $global-rounded;
+}
+
 /// Button Group
 ///
 /// @example scss


### PR DESCRIPTION
* Adds a `button-rounded` placeholder to use with any button
* Adds a set of `inverted` states for all types of buttons

**Usage e.g**
Next to `%button-primary`, `%button-primary-inverted` was added.

This would make it extremely easy to swap the two types, making default shallow buttons solid all at once.

**Preview**
Rounded and inverted icon buttons:
![screen shot 2015-09-23 at 15 39 59](https://cloud.githubusercontent.com/assets/1321353/10048152/842f6f62-6209-11e5-9196-aea0d8992ebd.png)

Rounded icon buttons:
![screen shot 2015-09-23 at 15 43 05](https://cloud.githubusercontent.com/assets/1321353/10048220/d08763ce-6209-11e5-815a-f8a974c501dc.png)
