### PR TITLE
Refactor layout component

### DIFF
--- a/components/_layout-deprecated.scss
+++ b/components/_layout-deprecated.scss
@@ -49,7 +49,7 @@ $layout-sidebar-nav-bubble-width: rem-calc(24) !default;
 $layout-sidebar-nav-bubble-background-color: $steel !default;
 $layout-sidebar-selector: '.sidebar' !default;
 
-$include-html-paint-layout: true !default;
+$include-html-paint-layout-deprecated: false !default;
 
 %layout-sidebar-heading {
   font-size: $layout-sidebar-heading-font-size;
@@ -118,7 +118,7 @@ $include-html-paint-layout: true !default;
           -webkit-font-smoothing: $body-font-smoothing;
           margin: 0;
           opacity: 1;
-          transition: 
+          transition:
             opacity $layout-sidebar-collapse-duration / 2 ease-in,
             width $layout-sidebar-collapse-duration / 1.5 ease-in;
           width: auto;
@@ -160,7 +160,7 @@ $include-html-paint-layout: true !default;
 }
 
 /// Global application layout styles
-/// 
+///
 /// @example - Default Usage
 ///   <body>
 ///     <div class="application">
@@ -175,7 +175,7 @@ $include-html-paint-layout: true !default;
 ///     </div>
 ///   </body>
 
-@mixin layout {
+@mixin layout-deprecated {
   html,
   body {
     height: 100%;
@@ -225,7 +225,7 @@ $include-html-paint-layout: true !default;
       line-height: $layout-sidebar-nav-title-height;
       margin: 0;
       transform: translate(0, 0);
-      transition: 
+      transition:
         transform $layout-sidebar-collapse-duration $global-transition-easing,
         opacity $layout-sidebar-collapse-duration ease-out;
       transition-delay: $global-transition-easing;
@@ -444,9 +444,9 @@ $include-html-paint-layout: true !default;
   }
 }
 
-@include exports('paint-layout') {
-  @if $include-html-paint-layout {
-    @include layout;
+@include exports('paint-layout-deprecated') {
+  @if $include-html-paint-layout-deprecated {
+    @include layout-deprecated;
     @include layout-sidebar;
   }
 }

--- a/components/_layout-deprecated.scss
+++ b/components/_layout-deprecated.scss
@@ -118,8 +118,7 @@ $include-html-paint-layout-deprecated: false !default;
           -webkit-font-smoothing: $body-font-smoothing;
           margin: 0;
           opacity: 1;
-          transition:
-            opacity $layout-sidebar-collapse-duration / 2 ease-in,
+          transition: opacity $layout-sidebar-collapse-duration / 2 ease-in,
             width $layout-sidebar-collapse-duration / 1.5 ease-in;
           width: auto;
         }
@@ -225,8 +224,7 @@ $include-html-paint-layout-deprecated: false !default;
       line-height: $layout-sidebar-nav-title-height;
       margin: 0;
       transform: translate(0, 0);
-      transition:
-        transform $layout-sidebar-collapse-duration $global-transition-easing,
+      transition: transform $layout-sidebar-collapse-duration $global-transition-easing,
         opacity $layout-sidebar-collapse-duration ease-out;
       transition-delay: $global-transition-easing;
       width: 80%;

--- a/components/_layout.scss
+++ b/components/_layout.scss
@@ -1,0 +1,74 @@
+////
+/// Layout Component.
+/// @group layout
+/// @since v0.8.29
+////
+
+/// Default settings
+
+$layout-default-settings: (
+  selectors: (
+    main: '.application',
+    content-wrapper: 'main',
+    content: '> .content'
+  )
+);
+
+$include-html-paint-layout: true !default;
+
+/// Global application layout styles
+///
+/// @example - Default Usage
+///   <body>
+///     <div class="application">
+///       <div class="main-navigation">
+///          // ...
+///       </div>
+///
+///       <main>
+///         <div class="content">
+///           //...
+///         </div>
+///       </main>
+///     </div>
+///   </body>
+
+$layout: () !default;
+$layout: map-merge-settings($layout-default-settings, $layout);
+
+@function layout-settings($setting, $property: null) {
+  @if $property {
+    @return map-get(map-get($layout, $setting), $property);
+  } @else {
+    @return map-get($layout, $setting);
+  }
+}
+
+@mixin layout {
+  html,
+  body {
+    height: 100%;
+    overflow: hidden;
+  }
+
+  #{layout-settings(selectors, main)} {
+    height: 100%;
+
+    #{layout-settings(selectors, content-wrapper)} {
+      height: 100%;
+      overflow: hidden;
+      position: relative;
+
+      #{layout-settings(selectors, content)} {
+        height: 100%;
+        overflow-y: auto;
+      }
+    }
+  }
+}
+
+@include exports('paint-layout') {
+  @if $include-html-paint-layout {
+    @include layout;
+  }
+}

--- a/components/_navigation.scss
+++ b/components/_navigation.scss
@@ -272,7 +272,7 @@ $include-html-paint-navigation: true !default;
   }
 }
 
-#{$layout-main-selector} {
+#{layout-settings(selectors, main)} {
   &.with-sidebar {
     margin-left: navigation-settings(height);
   }
@@ -519,7 +519,7 @@ $sidebar-full-open: '.part-open:hover';
 }
 
 @media #{$small-only} {
-  #{$layout-main-selector} {
+  #{layout-settings(selectors, main)} {
     &.with-sidebar {
       margin-left: 0;
     }

--- a/paint.scss
+++ b/paint.scss
@@ -22,6 +22,7 @@
 @import 'components/icon';
 @import 'components/notification';
 @import 'components/label';
+@import 'components/layout';
 @import 'components/layout-deprecated';
 @import 'components/navigation';
 @import 'components/table';

--- a/paint.scss
+++ b/paint.scss
@@ -22,7 +22,7 @@
 @import 'components/icon';
 @import 'components/notification';
 @import 'components/label';
-@import 'components/layout';
+@import 'components/layout-deprecated';
 @import 'components/navigation';
 @import 'components/table';
 @import 'components/progress-bar';


### PR DESCRIPTION
With the new navigation, most of the code from the layout component is deprecated.
This PR refactors the layout component to use the basic setup and keeps the old (deprecated) layout code until all apps are updated to use the latest navigation format.

For apps that require the latest paint version (`>0.8.27`) add to `paint-settings.css`
```scss
$include-html-paint-layout: false;
$include-html-paint-layout-deprecated: true;
```

