### PR TITLE
[Hotfix] Remove useless last-child declaration from the grid

### DIFF
--- a/components/_grid.scss
+++ b/components/_grid.scss
@@ -1,7 +1,7 @@
 ////
 /// Grid placeholders generator
 /// @group grid
-/// @since v0.8.5
+/// @since v0.8.28
 ////
 
 /// Grid placeholder prefix
@@ -20,10 +20,6 @@ $large-down: "#{$screen} and (max-width:#{upper-bound($large-range)})" !default;
   @for $i from 1 through $total-columns {
     %#{$prefix}-#{$i} {
       @include grid-column($columns: $i, $collapse: false, $float: true);
-
-      &:last-child {
-        @include grid-column($columns: $i, $collapse: false, $float: true, $last-column: true);
-      }
     }
 
     %#{$prefix}-#{$i}-centered {


### PR DESCRIPTION
The last-child declaration placeholder is useless within the grid-column, because if there's only one grid element it would float it right.

This can be replicated by creating an
```
<ul>
  <li>
    <div class="grid-element"></div>
  </li>
</ul>
```
with
```
.grid-element {
  @extend %grid-column-4;
}
```
In this case all divs are going to be right-aligned, being the last children within their wrappers.