### PR TITLE
Implement Steps component

### DIFF
--- a/.sassdocrc
+++ b/.sassdocrc
@@ -15,6 +15,7 @@ groups:
   modal: Modals
   dropdown: Dropdowns
   label: Labels
+  step: Steps
   navigation: Navigation
   tab: Tabs
   panel: Panels

--- a/components/_icon.scss
+++ b/components/_icon.scss
@@ -55,11 +55,15 @@ $paint-icons: (
 ///     @include icon(dashboard);
 ///   }
 
-@mixin icon($name) {
+@mixin icon($name, $selector: '') {
   @extend .fa-#{$name};
 
-  &:before {
+  @if $selector == '' {
     @include fa-icon;
+  } @else {
+    &:#{$selector} {
+      @include fa-icon;
+    }
   }
 }
 

--- a/components/_icon.scss
+++ b/components/_icon.scss
@@ -1,7 +1,7 @@
 ////
 /// Icons Component
 /// @group icon
-/// @since v0.8.16
+/// @since v0.8.32
 ////
 
 /// Extends FontAwesome icons and Paint icons
@@ -56,8 +56,11 @@ $paint-icons: (
 ///   }
 
 @mixin icon($name) {
-  @include fa-icon;
   @extend .fa-#{$name};
+
+  &:before {
+    @include fa-icon;
+  }
 }
 
 /// @access private

--- a/components/_step.scss
+++ b/components/_step.scss
@@ -9,10 +9,20 @@
 /// @example html - Steps with border and icons
 ///   <ol class="steps with-border with-icons">
 ///     <li><a>First Step</a></li>
-///     <li class="highlighted" ><a>Second Step</a></li>
+///     <li class="highlighted"><a>Second Step</a></li>
 ///     <li class="active"><span>Current</span></li>
 ///     <li><span>Inactive</span></li>
 ///     <li><span>Inactive</span></li>
+///     <li><span>Inactive</span></li>
+///   </ol>
+///
+/// @example html - Steps with border and counts
+///   <ol class="steps with-border with-counts">
+///     <li class="highlighted with-pre"><span>10</span><a>First Item</a></li>
+///     <li class="highlighted with-pre"><span>8</span><a>Second Item</a></li>
+///     <li class="active"><span>Current</span></li>
+///     <li class="with-post"><span>Inactive Item</span><span>0</span></li>
+///     <li class="with-post"><span>Inactive Item</span><span>0</span></li>
 ///     <li><span>Inactive</span></li>
 ///   </ol>
 ///
@@ -32,12 +42,18 @@
 ///   }
 
 $step-default-settings: (
-  height: $base-line-height * .75,
+  height: $button-small-height,
 
   colors: (
-    inactive: border,
-    highlighted: link,
-    active: primary
+    inactive-background: color(border, light),
+    inactive-border: color(border),
+    inactive-count: color(border),
+    highlighted-background: color(info, light),
+    highlighted-border: color(gray),
+    highlighted-count: color(gray),
+    active-background: color(primary, light),
+    active-border: color(primary),
+    active-count: color(primary, dark),
   ),
 
   selectors: (
@@ -68,7 +84,7 @@ $include-html-paint-step: true !default;
     margin: $column-gutter / 4 0;
 
     &::after {
-      color: color(step-settings(colors, inactive), dark);
+      color: step-settings(colors, inactive-border);
       content: '\00bb';
       display: inline-block;
       margin: 0 $column-gutter / 4;
@@ -79,41 +95,47 @@ $include-html-paint-step: true !default;
     }
 
     > * {
-      color: color(step-settings(colors, inactive), dark);
+      color: step-settings(colors, inactive-border);
       display: inline-block;
     }
 
     &#{step-settings(selectors, highlighted)} > * {
-      color: color(step-settings(colors, highlighted));
+      color: step-settings(colors, highlighted-border);
     }
 
     &#{step-settings(selectors, active)} > * {
-      color: color(step-settings(colors, active));
+      color: step-settings(colors, active-border);
     }
   }
 
   .no-touch & a:hover {
-    color: color(step-settings(colors, highlighted));
+    color: step-settings(colors, highlighted-border);
+  }
+}
+
+@mixin steps-default-icon {
+  @include icon(circle-o);
+
+  &:before {
+    margin-right: $column-gutter / 4;
   }
 }
 
 %steps-with-icons {
   li {
-    &#{step-settings(selectors, highlighted)} > * {
-     @include icon(check);
+    &#{step-settings(selectors, highlighted)} > *:first-child {
+      @include icon(check);
     }
 
-    &#{step-settings(selectors, active)} > * {
-     @include icon(dot-circle-o);
+    &#{step-settings(selectors, active)} > *:first-child {
+      @include icon(dot-circle-o);
     }
 
     > * {
-      @include icon(circle-o);
-
       line-height: step-settings(height) !important;
 
-      &:before {
-        margin-right: $column-gutter / 4;
+      &:first-child {
+        @include steps-default-icon;
       }
     }
   }
@@ -124,65 +146,140 @@ $include-html-paint-step: true !default;
     text-align: center;
 
     li {
-      position: relative;
       float: none;
       margin: $column-gutter / 4 $column-gutter $column-gutter / 4 0;
+      position: relative;
 
       &:last-of-type {
         margin-right: 0;
       }
 
       &::after {
-        background: color(step-settings(colors, inactive));
+        background: step-settings(colors, inactive-border);
         content: '';
-        height: 2px;
+        height: 1px;
         left: 100%;
         margin: 0;
         position: absolute;
         top: 50%;
         transform: translateY(-50%) translateX(-1px);
-        width: 100%;
+        width: 50%;
       }
 
       &#{step-settings(selectors, highlighted)} {
         &:after {
-          background-color: color(step-settings(colors, highlighted));
+          background-color: step-settings(colors, highlighted-border);
         }
 
         > * {
-          color: contrast(color(step-settings(colors, highlighted)));
-          background-color: color(step-settings(colors, highlighted));
+          @include detached-border(step-settings(colors, highlighted-border));
+
+          background-color: step-settings(colors, highlighted-background);
+          color: contrast(step-settings(colors, highlighted-background));
         }
       }
 
-      &#{step-settings(selectors, active)} {
-        &:after {
-          background-color: color(step-settings(colors, active));
-        }
+      &#{step-settings(selectors, active)} > * {
+        @include detached-border(step-settings(colors, active-border));
 
-        > * {
-          color: contrast(color(step-settings(colors, active)));
-          background-color: color(step-settings(colors, active));
-        }
+        background-color: step-settings(colors, active-background);
+        color: contrast(step-settings(colors, active-background));
       }
 
       > * {
-        background-color: color(step-settings(colors, inactive));
+        @include detached-border(step-settings(colors, inactive-border));
+
+        background-color: step-settings(colors, inactive-background);
         border-radius: $global-radius;
-        color: color(step-settings(colors, inactive), dark);
+        color: contrast(step-settings(colors, inactive-background));
         line-height: step-settings(height);
-        padding: $column-gutter / 4 $column-gutter / 2 !important;
+        padding: 0 $column-gutter / 2 !important;
         position: relative;
         z-index: 1;
       }
 
-      .no-touch & > *:hover {
-        background-color: color(step-settings(colors, highlighted), dark);
+      .no-touch & > a:hover {
+        background-color: step-settings(colors, highlighted-border);
+        color: contrast(step-settings(colors, highlighted-border));
       }
-
     }
   }
 };
+
+%steps-with-counts {
+  li {
+    &.with-pre > *:first-child,
+    &.with-post > *:last-child {
+      font-weight: $font-weight-bold;
+    }
+
+    &.with-pre > *:first-child {
+      padding-right: $column-gutter / 6;
+    }
+
+    &.with-post > *:last-child {
+      padding-left: $column-gutter / 6;
+    }
+  }
+
+  @media #{$medium-up} {
+    .with-pre > *:first-child,
+    .with-post > *:last-child {
+      padding-left: $column-gutter / 6;
+      padding-right: $column-gutter / 6;
+    }
+
+    .with-pre {
+      &#{step-settings(selectors, highlighted)} > *:first-child {
+        background-color: step-settings(colors, highlighted-count);
+        color: contrast(step-settings(colors, highlighted-count));
+      }
+
+      &#{step-settings(selectors, active)} > *:first-child {
+        background-color: step-settings(colors, active-count);
+        color: contrast(step-settings(colors, active-count));
+      }
+
+      > *:first-child {
+        background-color: step-settings(colors, inactive-count);
+        border-bottom-right-radius: 0;
+        border-top-right-radius: 0;
+        color: contrast(step-settings(colors, inactive-count));
+      }
+
+      > *:last-child {
+        border-bottom-left-radius: 0;
+        border-left-width: 0;
+        border-top-left-radius: 0;
+      }
+    }
+
+    .with-post {
+      &#{step-settings(selectors, highlighted)} > *:last-child {
+        background-color: step-settings(colors, highlighted-count);
+        color: contrast(step-settings(colors, highlighted-count));
+      }
+
+      &#{step-settings(selectors, active)} > *:last-child {
+        background-color: step-settings(colors, active-count);
+        color: contrast(step-settings(colors, active-count));
+      }
+
+      > *:first-child {
+        border-bottom-right-radius: 0;
+        border-right-width: 0;
+        border-top-right-radius: 0;
+      }
+
+      > *:last-child {
+        background-color: step-settings(colors, inactive-count);
+        border-bottom-left-radius: 0;
+        border-top-left-radius: 0;
+        color: contrast(step-settings(colors, inactive-count));
+      }
+    }
+  }
+}
 
 @include exports('paint-step') {
   @if $include-html-paint-step {
@@ -195,6 +292,10 @@ $include-html-paint-step: true !default;
 
       &.with-icons {
         @extend %steps-with-icons;
+      }
+
+      &.with-counts {
+        @extend %steps-with-counts;
       }
     }
   }

--- a/components/_step.scss
+++ b/components/_step.scss
@@ -1,7 +1,7 @@
 ////
 /// Steps
 /// @group step
-/// @since v0.8.32
+/// @since v0.8.33
 ////
 
 /// Default settings
@@ -185,9 +185,10 @@ $include-html-paint-step: true !default;
           background-color: step-settings(colors, highlighted-background);
           color: contrast(step-settings(colors, highlighted-background));
 
-          &:hover {
-            background-color: lighten(step-settings(colors, highlighted-background), 3%);
-          }
+        }
+
+        > *:hover {
+          background-color: lighten(step-settings(colors, highlighted-background), 3%);
         }
       }
 

--- a/components/_step.scss
+++ b/components/_step.scss
@@ -1,6 +1,6 @@
 ////
 /// Steps
-/// @group steps
+/// @group step
 /// @since v0.8.32
 ////
 
@@ -75,6 +75,8 @@ $include-html-paint-step: true !default;
   }
 }
 
+/// Default steps placeholder, acts like a breadcrumb
+
 %steps {
   @extend %grid-row;
 
@@ -121,6 +123,9 @@ $include-html-paint-step: true !default;
   }
 }
 
+/// Steps extention placeholder, allows use of icons
+/// @require {placeholder} steps
+
 %steps-with-icons {
   li {
     &#{step-settings(selectors, highlighted)} > *:first-child {
@@ -140,6 +145,9 @@ $include-html-paint-step: true !default;
     }
   }
 }
+
+/// Steps extention placeholder, adds a border around elements
+/// @require {placeholder} steps
 
 %steps-with-border {
   @media #{$medium-up} {
@@ -205,6 +213,10 @@ $include-html-paint-step: true !default;
     }
   }
 };
+
+/// Steps extention placeholder, allows adding pre or post content
+/// @require {placeholder} steps
+/// @require {placeholder} steps-with-border
 
 %steps-with-counts {
   li {

--- a/components/_step.scss
+++ b/components/_step.scss
@@ -1,0 +1,193 @@
+/// @example - Usage
+///   <nav>
+///     <ol class="steps text-center with-icons">
+///       <li class="visited"><a href="#">Step 1</a></li>
+///       <li class="visited" ><a href="#">Step 2</a></li>
+///       <li class="current"><em>Step 3</em></li>
+///       <li><em>Finish</em></li>
+///     </ol>
+///   </nav>
+
+
+$step-default-settings: (
+  colors: (
+    inactive: color(border),
+    active: color(primary),
+    hover: color(primary, dark)
+  )
+);
+
+$step: () !default;
+$step: map-merge-settings($step-default-settings, $step);
+
+$include-html-paint-step: true !default;
+
+@function step-settings($setting, $property: null) {
+  @if $property {
+    @return map-get(map-get($step, $setting), $property);
+  } @else {
+    @return map-get($step, $setting);
+  }
+}
+
+.steps {
+	width: 90%;
+	max-width: 100%;
+	padding: 0 $column-gutter / 2;
+	margin: 0 auto;
+  clear: both;
+
+	li {
+		display: inline-block;
+		float: left;
+		margin: $column-gutter / 4 0;
+
+		&::after {
+			/* separator */
+			display: inline-block;
+			content: '\00bb';
+			margin: 0 .6em;
+			color: step-settings(colors, inactive);
+		}
+
+		&:last-of-type::after {
+			display: none;
+		}
+
+    > * {
+  		/* single item */
+  		display: inline-block;
+  		font-size: $base-font-size;
+  		color: step-settings(colors, active);
+	  }
+
+    &.current > * {
+  		/* current item */
+  		color: step-settings(colors, current);
+  	}
+  }
+
+	.no-touch & a:hover {
+		/* previous items */
+		color: step-settings(colors, active);
+	}
+
+	&.custom-separator li::after {
+		@include icon(arrow-right);
+
+		vertical-align: middle;
+	}
+
+	&.with-icons li > *::before {
+		/* add a custom icon before each item */
+    @include icon(check);
+
+		content: '';
+		display: inline-block;
+		height: 20px;
+		width: 20px;
+		margin-right: $column-gutter / 4;
+		margin-top: -2px;
+		vertical-align: middle;
+	}
+
+	&.with-icons li:not(.current):nth-of-type(2) > *::before {
+		@include paint-icon(dashboard);
+	}
+
+	&.with-icons li:not(.current):nth-of-type(3) > *::before {
+		@include paint-icon(cog);
+	}
+
+	&.with-icons li.current:first-of-type > *::before {
+		@include paint-icon(video);
+	}
+
+	@media #{$medium-up} {
+		padding: 0;
+
+		li {
+			margin: 0;
+
+			&::after {
+				margin: 0 $column-gutter;
+			}
+		}
+
+		li > * {
+			font-size: $small-font-size;
+		}
+	}
+}
+
+@media #{$medium-up} {
+  .steps {
+    background-color: transparent;
+    padding: 0;
+    text-align: center;
+
+    li {
+      position: relative;
+      float: none;
+      margin: $column-gutter / 4 $column-gutter $column-gutter / 4 0;
+
+      &:last-of-type {
+        margin-right: 0;
+      }
+
+      &::after {
+        /* connector */
+        position: absolute;
+        content: '';
+        height: 4px;
+        background: step-settings(colors, inactive);
+
+        margin: 0;
+      }
+
+      &.visited::after {
+        background-color: step-settings(colors, active);
+      }
+
+      & > *, &.current > * {
+        position: relative;
+        color: step-settings(colors, active);
+      }
+    }
+
+    &.custom-separator li::after {
+      height: 4px;
+      background: step-settings(colors, inactive);
+    }
+
+    &.text-center {
+      li::after {
+        width: 100%;
+        top: 50%;
+        left: 100%;
+        transform: translateY(-50%) translateX(-1px);
+      }
+
+      li > * {
+        z-index: 1;
+        padding: $column-gutter / 4 $column-gutter / 2;
+        border-radius: $global-radius;
+        background-color: step-settings(colors, inactive);
+      }
+
+      .no-touch & a:hover {
+        background-color: step-settings(colors, hover);
+      }
+
+      li.current > *, li.visited > * {
+        color: contrast(step-settings(colors, hover));
+        background-color: step-settings(colors, active);
+      }
+
+      &.with-icons li.visited a::before {
+        /* visited icon */
+        @include icon(check);
+      }
+    }
+  }
+}

--- a/components/_step.scss
+++ b/components/_step.scss
@@ -184,6 +184,10 @@ $include-html-paint-step: true !default;
 
           background-color: step-settings(colors, highlighted-background);
           color: contrast(step-settings(colors, highlighted-background));
+
+          &:hover {
+            background-color: lighten(step-settings(colors, highlighted-background), 3%);
+          }
         }
       }
 
@@ -192,6 +196,10 @@ $include-html-paint-step: true !default;
 
         background-color: step-settings(colors, active-background);
         color: contrast(step-settings(colors, active-background));
+
+        &:hover {
+          background-color: lighten(step-settings(colors, active-background), 7%);
+        }
       }
 
       > * {
@@ -204,11 +212,10 @@ $include-html-paint-step: true !default;
         padding: 0 $column-gutter / 2 !important;
         position: relative;
         z-index: 1;
-      }
 
-      .no-touch & > a:hover {
-        background-color: step-settings(colors, highlighted-border);
-        color: contrast(step-settings(colors, highlighted-border));
+        &:hover {
+          background-color: lighten(step-settings(colors, inactive-background), 3%);
+        }
       }
     }
   }

--- a/components/_step.scss
+++ b/components/_step.scss
@@ -1,19 +1,48 @@
-/// @example - Usage
-///   <nav>
-///     <ol class="steps text-center with-icons">
-///       <li class="visited"><a href="#">Step 1</a></li>
-///       <li class="visited" ><a href="#">Step 2</a></li>
-///       <li class="current"><em>Step 3</em></li>
-///       <li><em>Finish</em></li>
-///     </ol>
-///   </nav>
+////
+/// Steps
+/// @group steps
+/// @since v0.8.32
+////
 
+/// Default settings
+
+/// @example html - Steps with border and icons
+///   <ol class="steps with-border with-icons">
+///     <li><a>First Step</a></li>
+///     <li class="highlighted" ><a>Second Step</a></li>
+///     <li class="active"><span>Current</span></li>
+///     <li><span>Inactive</span></li>
+///     <li><span>Inactive</span></li>
+///     <li><span>Inactive</span></li>
+///   </ol>
+///
+/// @example scss - Custom steps
+///   .basic-breadbrumb,
+///   .border-steps,
+///   .icon-steps {
+///     @extend %steps;
+///   }
+///
+///   .icon-steps {
+///     @extend %steps-with-icons;
+///   }
+///
+///   .border-steps {
+///     @extend %steps-with-border;
+///   }
 
 $step-default-settings: (
+  height: $base-line-height * .75,
+
   colors: (
-    inactive: color(border),
-    active: color(primary),
-    hover: color(primary, dark)
+    inactive: border,
+    highlighted: link,
+    active: primary
+  ),
+
+  selectors: (
+    highlighted: '.highlighted',
+    active: '.active'
   )
 );
 
@@ -30,100 +59,68 @@ $include-html-paint-step: true !default;
   }
 }
 
-.steps {
-	width: 90%;
-	max-width: 100%;
-	padding: 0 $column-gutter / 2;
-	margin: 0 auto;
-  clear: both;
+%steps {
+  @extend %grid-row;
 
-	li {
-		display: inline-block;
-		float: left;
-		margin: $column-gutter / 4 0;
+  li {
+    display: inline-block;
+    float: left;
+    margin: $column-gutter / 4 0;
 
-		&::after {
-			/* separator */
-			display: inline-block;
-			content: '\00bb';
-			margin: 0 .6em;
-			color: step-settings(colors, inactive);
-		}
+    &::after {
+      color: color(step-settings(colors, inactive), dark);
+      content: '\00bb';
+      display: inline-block;
+      margin: 0 $column-gutter / 4;
+    }
 
-		&:last-of-type::after {
-			display: none;
-		}
+    &:last-of-type::after {
+      display: none;
+    }
 
     > * {
-  		/* single item */
-  		display: inline-block;
-  		font-size: $base-font-size;
-  		color: step-settings(colors, active);
-	  }
+      color: color(step-settings(colors, inactive), dark);
+      display: inline-block;
+    }
 
-    &.current > * {
-  		/* current item */
-  		color: step-settings(colors, current);
-  	}
+    &#{step-settings(selectors, highlighted)} > * {
+      color: color(step-settings(colors, highlighted));
+    }
+
+    &#{step-settings(selectors, active)} > * {
+      color: color(step-settings(colors, active));
+    }
   }
 
-	.no-touch & a:hover {
-		/* previous items */
-		color: step-settings(colors, active);
-	}
-
-	&.custom-separator li::after {
-		@include icon(arrow-right);
-
-		vertical-align: middle;
-	}
-
-	&.with-icons li > *::before {
-		/* add a custom icon before each item */
-    @include icon(check);
-
-		content: '';
-		display: inline-block;
-		height: 20px;
-		width: 20px;
-		margin-right: $column-gutter / 4;
-		margin-top: -2px;
-		vertical-align: middle;
-	}
-
-	&.with-icons li:not(.current):nth-of-type(2) > *::before {
-		@include paint-icon(dashboard);
-	}
-
-	&.with-icons li:not(.current):nth-of-type(3) > *::before {
-		@include paint-icon(cog);
-	}
-
-	&.with-icons li.current:first-of-type > *::before {
-		@include paint-icon(video);
-	}
-
-	@media #{$medium-up} {
-		padding: 0;
-
-		li {
-			margin: 0;
-
-			&::after {
-				margin: 0 $column-gutter;
-			}
-		}
-
-		li > * {
-			font-size: $small-font-size;
-		}
-	}
+  .no-touch & a:hover {
+    color: color(step-settings(colors, highlighted));
+  }
 }
 
-@media #{$medium-up} {
-  .steps {
-    background-color: transparent;
-    padding: 0;
+%steps-with-icons {
+  li {
+    &#{step-settings(selectors, highlighted)} > * {
+     @include icon(check);
+    }
+
+    &#{step-settings(selectors, active)} > * {
+     @include icon(dot-circle-o);
+    }
+
+    > * {
+      @include icon(circle-o);
+
+      line-height: step-settings(height) !important;
+
+      &:before {
+        margin-right: $column-gutter / 4;
+      }
+    }
+  }
+}
+
+%steps-with-border {
+  @media #{$medium-up} {
     text-align: center;
 
     li {
@@ -136,57 +133,68 @@ $include-html-paint-step: true !default;
       }
 
       &::after {
-        /* connector */
-        position: absolute;
+        background: color(step-settings(colors, inactive));
         content: '';
-        height: 4px;
-        background: step-settings(colors, inactive);
-
-        margin: 0;
-      }
-
-      &.visited::after {
-        background-color: step-settings(colors, active);
-      }
-
-      & > *, &.current > * {
-        position: relative;
-        color: step-settings(colors, active);
-      }
-    }
-
-    &.custom-separator li::after {
-      height: 4px;
-      background: step-settings(colors, inactive);
-    }
-
-    &.text-center {
-      li::after {
-        width: 100%;
-        top: 50%;
+        height: 2px;
         left: 100%;
+        margin: 0;
+        position: absolute;
+        top: 50%;
         transform: translateY(-50%) translateX(-1px);
+        width: 100%;
       }
 
-      li > * {
-        z-index: 1;
-        padding: $column-gutter / 4 $column-gutter / 2;
+      &#{step-settings(selectors, highlighted)} {
+        &:after {
+          background-color: color(step-settings(colors, highlighted));
+        }
+
+        > * {
+          color: contrast(color(step-settings(colors, highlighted)));
+          background-color: color(step-settings(colors, highlighted));
+        }
+      }
+
+      &#{step-settings(selectors, active)} {
+        &:after {
+          background-color: color(step-settings(colors, active));
+        }
+
+        > * {
+          color: contrast(color(step-settings(colors, active)));
+          background-color: color(step-settings(colors, active));
+        }
+      }
+
+      > * {
+        background-color: color(step-settings(colors, inactive));
         border-radius: $global-radius;
-        background-color: step-settings(colors, inactive);
+        color: color(step-settings(colors, inactive), dark);
+        line-height: step-settings(height);
+        padding: $column-gutter / 4 $column-gutter / 2 !important;
+        position: relative;
+        z-index: 1;
       }
 
-      .no-touch & a:hover {
-        background-color: step-settings(colors, hover);
+      .no-touch & > *:hover {
+        background-color: color(step-settings(colors, highlighted), dark);
       }
 
-      li.current > *, li.visited > * {
-        color: contrast(step-settings(colors, hover));
-        background-color: step-settings(colors, active);
+    }
+  }
+};
+
+@include exports('paint-step') {
+  @if $include-html-paint-step {
+    .steps {
+      @extend %steps;
+
+      &.with-border {
+        @extend %steps-with-border;
       }
 
-      &.with-icons li.visited a::before {
-        /* visited icon */
-        @include icon(check);
+      &.with-icons {
+        @extend %steps-with-icons;
       }
     }
   }

--- a/components/_step.scss
+++ b/components/_step.scss
@@ -114,7 +114,7 @@ $include-html-paint-step: true !default;
 }
 
 @mixin steps-icon-default {
-  @include icon(circle-o);
+  @include icon(circle-o, before);
 
   &:before {
     margin-right: $column-gutter / 4;
@@ -124,11 +124,11 @@ $include-html-paint-step: true !default;
 %steps-with-icons {
   li {
     &#{step-settings(selectors, highlighted)} > *:first-child {
-      @include icon(check);
+      @include icon(check, before);
     }
 
     &#{step-settings(selectors, active)} > *:first-child {
-      @include icon(dot-circle-o);
+      @include icon(dot-circle-o, before);
     }
 
     > * {

--- a/components/_step.scss
+++ b/components/_step.scss
@@ -135,7 +135,7 @@ $include-html-paint-step: true !default;
       line-height: step-settings(height) !important;
 
       &:first-child {
-        @include step-icon-default;
+        @include steps-icon-default;
       }
     }
   }

--- a/components/_step.scss
+++ b/components/_step.scss
@@ -113,7 +113,7 @@ $include-html-paint-step: true !default;
   }
 }
 
-@mixin steps-default-icon {
+@mixin steps-icon-default {
   @include icon(circle-o);
 
   &:before {
@@ -135,7 +135,7 @@ $include-html-paint-step: true !default;
       line-height: step-settings(height) !important;
 
       &:first-child {
-        @include steps-default-icon;
+        @include step-icon-default;
       }
     }
   }


### PR DESCRIPTION
1. `@extend %steps` _(can be used as breadcrumb)_, 
2. Steps with icons `@extend %steps; @extend %steps-with-icons;`
3. Steps with border `@extend %steps; @extend %steps-with-border; @extend %steps-with-icons;`
4. Steps with border and counts `@extend %steps; @extend %steps-with-border; @extend %steps-with-counts`
<img width="965" alt="screen shot 2015-10-14 at 15 55 57" src="https://cloud.githubusercontent.com/assets/1321353/10513752/a552623c-7341-11e5-94c9-fe38d5519a33.png">

Multi-line support
<img width="585" alt="screen shot 2015-10-15 at 13 34 07" src="https://cloud.githubusercontent.com/assets/1321353/10513760/b723eef4-7341-11e5-92cc-d636902adfa5.png">

Small screen
<img width="493" alt="screen shot 2015-10-15 at 13 34 43" src="https://cloud.githubusercontent.com/assets/1321353/10513767/bfc28fac-7341-11e5-81c7-c43410ed85cb.png">


Example markup:
```
      <ol class="steps with-border with-counts">
        <li class="highlighted with-pre"><span>10</span><a>First Item</a></li>
        <li class="highlighted with-pre"><span>8</span><a>Second Item</a></li>
        <li class="active"><span>Current</span></li>
        <li class="with-post"><span>Inactive Item</span><span>0</span></li>
        <li class="with-post"><span>Inactive Item</span><span>0</span></li>
        <li><span>Inactive</span></li>
      </ol>
```

**ToDo**
- [x] Implement refined design
- [x] Add documentation