### PR TITLE
Fix a possible bug where a selector is passed as a string

### DIFF
--- a/components/_layout.scss
+++ b/components/_layout.scss
@@ -37,10 +37,16 @@ $layout: () !default;
 $layout: map-merge-settings($layout-default-settings, $layout);
 
 @function layout-settings($setting, $property: null) {
+  $output: map-get($layout, $setting);
+
   @if $property {
-    @return map-get(map-get($layout, $setting), $property);
+    $output: map-get(map-get($layout, $setting), $property);
+  }
+
+  @if type-of($output) == string {
+    @return unquote($output);
   } @else {
-    @return map-get($layout, $setting);
+    @return $output;
   }
 }
 

--- a/components/_navigation.scss
+++ b/components/_navigation.scss
@@ -172,10 +172,16 @@ $no-touch-selector: '.no-touch' !default;
 $include-html-paint-navigation: true !default;
 
 @function navigation-settings($setting, $property: null) {
+  $output: map-get($navigation, $setting);
+
   @if $property {
-    @return map-get(map-get($navigation, $setting), $property);
+    $output: map-get(map-get($navigation, $setting), $property);
+  }
+
+  @if type-of($output) == string {
+    @return unquote($output);
   } @else {
-    @return map-get($navigation, $setting);
+    @return $output;
   }
 }
 


### PR DESCRIPTION
Some versions of libsass would return dynamic class names returned from functions as strings.
This adds an extra check to the type of value to prevent any class rendering issues

E.g

```scss
$map: (
  selector: '.class'
);

#{map-get($map, selector)} {
   background-color: white;
}
```
sometimes renders like
```scss
".class" {
  background-color: white;
}
```
instead of
```scss
.class {
  background-color: white;
}
```
