### PR TITLE
Update the component settings parser to return unquoted valules for selectors

### DIFF
--- a/components/_progress-bar.scss
+++ b/components/_progress-bar.scss
@@ -56,10 +56,16 @@ $progress-bar: map-merge-settings($progress-bar-default-settings, $progress-bar)
 $include-html-paint-progress-bar: true !default;
 
 @function progress-bar-settings($setting, $property: null) {
+  $output: map-get($progress-bar, $setting);
+
   @if $property {
-    @return map-get(map-get($progress-bar, $setting), $property);
+    $output: map-get(map-get($progress-bar, $setting), $property);
+  }
+
+  @if type-of($output) == string {
+    @return unquote($output);
   } @else {
-    @return map-get($progress-bar, $setting);
+    @return $output;
   }
 }
 

--- a/components/_step.scss
+++ b/components/_step.scss
@@ -68,10 +68,16 @@ $step: map-merge-settings($step-default-settings, $step);
 $include-html-paint-step: true !default;
 
 @function step-settings($setting, $property: null) {
+  $output: map-get($step, $setting);
+
   @if $property {
-    @return map-get(map-get($step, $setting), $property);
+    $output: map-get(map-get($step, $setting), $property);
+  }
+
+  @if type-of($output) == string {
+    @return unquote($output);
   } @else {
-    @return map-get($step, $setting);
+    @return $output;
   }
 }
 

--- a/components/_tab.scss
+++ b/components/_tab.scss
@@ -48,10 +48,16 @@ $tab: map-merge-settings($tab-default-settings, $tab);
 $include-html-paint-tabs: true !default;
 
 @function tab-settings($setting, $property: null) {
+  $output: map-get($tab, $setting);
+
   @if $property {
-    @return map-get(map-get($tab, $setting), $property);
+    $output: map-get(map-get($tab, $setting), $property);
+  }
+
+  @if type-of($output) == string {
+    @return unquote($output);
   } @else {
-    @return map-get($tab, $setting);
+    @return $output;
   }
 }
 
@@ -144,8 +150,7 @@ $include-html-paint-tabs: true !default;
     left: 0;
     position: absolute;
     transform: translate(0, 150%);
-    transition: 
-      transform tab-settings(transition-duration),
+    transition: transform tab-settings(transition-duration),
       background-color tab-settings(transition-duration);
     width: 100%;
   }


### PR DESCRIPTION
Some versions of libsass would render map values as strings, so interpolating map values could return e.g. class names wrapped in quotes like `".weird-class-names"`.

This fixes the function settings parser to prevent that from happening _(in all components that use computed selectors)_