### PR TITLE
Hotfix/v0.8.42

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "paint",
-  "version": "0.8.41",
+  "version": "0.8.42",
   "homepage": "https://github.com/alphasights/paint",
   "authors": [
     "Eugenio Depalo <eugenio@alphasights.com>",

--- a/components/_form.scss
+++ b/components/_form.scss
@@ -103,6 +103,7 @@ $include-html-paint-form: true !default;
 
   font-size: $base-font-size;
   line-height: $form-input-height;
+  height: $form-input-height;
   margin-bottom: 0;
   padding: 0 $form-input-padding / 2;
 

--- a/components/_form.scss
+++ b/components/_form.scss
@@ -102,7 +102,6 @@ $include-html-paint-form: true !default;
   @include form-input-shared-properties;
 
   font-size: $base-font-size;
-  line-height: $form-input-height;
   height: $form-input-height;
   margin-bottom: 0;
   padding: 0 $form-input-padding / 2;

--- a/components/_form.scss
+++ b/components/_form.scss
@@ -102,6 +102,7 @@ $include-html-paint-form: true !default;
   @include form-input-shared-properties;
 
   font-size: $base-font-size;
+  line-height: $form-input-height;
   height: $form-input-height;
   margin-bottom: 0;
   padding: 0 $form-input-padding / 2;


### PR DESCRIPTION
Strangely IE renders cut form inputs, this fixes the issue of some inputs appearing too short like so:
<img width="568" alt="screen shot 2015-11-04 at 11 56 22 pm" src="https://github-cloud.s3.amazonaws.com/assets%2F497142%2F10961016%2Fb01a1ce6-834f-11e5-9200-edf7d3427c4b.png">



