### PR TITLE
Add ellipsis modifier to the labels

### DIFF
--- a/components/_label.scss
+++ b/components/_label.scss
@@ -100,6 +100,15 @@ $label: map-merge-settings($label-default-settings, $label);
   }
 }
 
+/// Label modifier - ellipsis. Extend to enable text-ellipsis
+/// when having long text items
+
+%label-ellipsis {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 /// Generates label style and size placeholders
 /// @access private
 


### PR DESCRIPTION
:point_up:

Is going to hide the label text if the label is bigger than the parent container

Used as a modifier
```scss
@extend %label-base;
@extend %label-ellipsis;
```