### PR TITLE
Fix rails-sass vs libsass string interpreting issue

### DIFF
--- a/globals/functions/_bem.scss
+++ b/globals/functions/_bem.scss
@@ -3,7 +3,8 @@ $bem-modifier-separator: '--';
 
 @function _bem-selector-to-string($selector) {
   $selector: inspect($selector);
-  $selector: str-slice($selector, 2, -2);
+  $dot-index: str-index($selector, ".");
+  $selector: str-slice($selector, $dot-index, -1);
 
   @return $selector;
 }

--- a/globals/functions/_bem.scss
+++ b/globals/functions/_bem.scss
@@ -3,7 +3,7 @@ $bem-modifier-separator: '--';
 
 @function _bem-selector-to-string($selector) {
   $selector: inspect($selector);
-  $dot-index: str-index($selector, ".");
+  $dot-index: str-index($selector, ".") + 1;
   $selector: str-slice($selector, $dot-index, -1);
 
   @return $selector;


### PR DESCRIPTION
**Issue**
BEM elements nested within modifiers were generating double dot class names _(`.block--modifier ..element` - which ends with a compiler error)_. This issue appears to be **rails-sass only**, due to the different output of the `inspect` function. In libsass it returns an unquoted string, in rails-sass is returning a quoted string in parenthesis _(wot)_.

**Fix**
When stripping the block name from the selector, start from the position of the dot and not from the beginning of the string.

Now the output class names are going to be the same.