### PR TITLE
Allow generating bem classes using pseudo-selectors instead of modifiers

### DIFF
--- a/globals/functions/_bem.scss
+++ b/globals/functions/_bem.scss
@@ -3,7 +3,7 @@ $bem-modifier-separator: '--';
 
 @function _bem-selector-to-string($selector) {
   $selector: inspect($selector);
-  $dot-index: str-index($selector, ".") + 1;
+  $dot-index: str-index($selector, '.') + 1;
   $selector: str-slice($selector, $dot-index, -1);
 
   @return $selector;
@@ -12,7 +12,7 @@ $bem-modifier-separator: '--';
 @function _bem-selector-has-modifier($selector) {
   $selector: _bem-selector-to-string($selector);
 
-  @if str-index($selector, $bem-modifier-separator) {
+  @if str-index($selector, $bem-modifier-separator) or str-index($selector, ':') {
     @return true;
   } @else {
     @return false;
@@ -21,7 +21,13 @@ $bem-modifier-separator: '--';
 
 @function _bem-get-block-name($selector) {
   $selector: _bem-selector-to-string($selector);
-  $modifier-start: str-index($selector, $bem-modifier-separator) - 1;
+  $modifier-separator: $bem-modifier-separator;
+
+  @if str-index($selector, ':') {
+    $modifier-separator: ':';
+  }
+
+  $modifier-start: str-index($selector, $modifier-separator) - 1;
 
   @return str-slice($selector, 0, $modifier-start);
 }


### PR DESCRIPTION
**What's Up**

Sometimes we want to define pseudo-selectors like `:hover` or `:first-child` as modifiers for blocks or elements.
The BEM structure was generated only if elements were properly wrapped in `bem-modifier` mixins. Not anymore.

This PR allows writing

```scss
@include bem-block('pseudoblock') {
  &:hover {
    @include bem-element('elementname') {
      @include bem-modifier('elementmodifier') {
      }
    }
  }
}
```

that would generate the following structure

```
.pseudoblock
.pseudoblock:hover
.pseudoblock:hover .pseudoblock__elementname
.pseudoblock:hover .pseudoblock__elementname--elementmodifier
```

----

_Next version would allow passing the modifier as `@include ben-modifier(':hover')`_, but that requires some refactoring.