### PR TITLE
Add placeholder option to generate tabs

### DIFF
--- a/components/_tab.scss
+++ b/components/_tab.scss
@@ -162,6 +162,17 @@ $include-html-paint-tabs: true !default;
 
 /// Tabs placeholders
 ///
+/// @example html - BEM Structure
+///   %tabs
+///     %tabs__nav
+///
+///   %tabs-nav
+///     %tabs-nav__item
+///       %tabs-nav__link
+///
+///   %tabs-nav--fluid-widths
+///   %tabs-nav--fluid-widths__item
+///
 /// @example scss - Usage
 ///   @include bem-block('custom-tabs') {
 ///     @extend %tabs;

--- a/components/_tab.scss
+++ b/components/_tab.scss
@@ -192,8 +192,8 @@ $include-html-paint-tabs: true !default;
 ///       // @extend %tabs-nav--fluid-widths__item; // optional
 ///     }
 ///
-///     @include bem-element('item-link') {
-///       @extend %tabs-nav__item-link;
+///     @include bem-element('link') {
+///       @extend %tabs-nav__link;
 ///     }
 ///   }
 ///

--- a/components/_tab.scss
+++ b/components/_tab.scss
@@ -184,9 +184,11 @@ $include-html-paint-tabs: true !default;
 ///
 ///   @include bem-block('custom-tabs-nav') {
 ///     @extend %tabs-nav;
+///     // @extend %tabs-nav--fluid-widths; // optional
 ///
 ///     @include bem-element('item') {
 ///       @extend %tabs-nav__item;
+///       // @extend %tabs-nav--fluid-widths__item; // optional
 ///     }
 ///
 ///     @include bem-element('item-link') {

--- a/components/_tab.scss
+++ b/components/_tab.scss
@@ -4,7 +4,7 @@
 /// @since v0.8.18
 ////
 
-/// Default settings
+/// Default settings - Deprecating in favor of the placeholders
 
 /// @example scss - Usage
 ///   .my-tabs {

--- a/components/_tab.scss
+++ b/components/_tab.scss
@@ -213,6 +213,14 @@ $include-html-paint-tabs: true !default;
   position: relative;
   white-space: nowrap;
 
+  &--fluid-widths {
+    display: flex;
+
+    &__item {
+      flex: 1;
+    }
+  }
+
   &__item {
     display: inline-block;
     list-style: none;

--- a/components/_tab.scss
+++ b/components/_tab.scss
@@ -161,6 +161,7 @@ $include-html-paint-tabs: true !default;
 }
 
 /// Tabs placeholders
+/// @since 0.9.15
 ///
 /// @example html - BEM Structure
 ///   %tabs
@@ -217,6 +218,10 @@ $include-html-paint-tabs: true !default;
     overflow: hidden;
   }
 }
+
+/// Block: tabs-nav
+/// Elements: item, link
+/// Modifiers: fluid-widths - affects item
 
 %tabs-nav {
   margin: 0;

--- a/components/_tab.scss
+++ b/components/_tab.scss
@@ -235,7 +235,9 @@ $include-html-paint-tabs: true !default;
     display: flex;
 
     &__item {
-      flex: 1;
+      @media #{$medium-up} {
+        flex: 1;
+      }
     }
   }
 

--- a/components/_tab.scss
+++ b/components/_tab.scss
@@ -160,6 +160,114 @@ $include-html-paint-tabs: true !default;
   }
 }
 
+/// Tabs placeholders
+///
+/// @example scss - Usage
+///   @include bem-block('custom-tabs') {
+///     @extend %tabs;
+///
+///     @include bem-element('nav') {
+///       @extend %tabs__nav;
+///     }
+///   }
+///
+///   @include bem-block('custom-tabs-nav') {
+///     @extend %tabs-nav;
+///
+///     @include bem-element('item') {
+///       @extend %tabs-nav__item;
+///     }
+///
+///     @include bem-element('item-link') {
+///       @extend %tabs-nav__item-link;
+///     }
+///   }
+///
+/// @example html - Usage
+///   <div class="newtabs">
+///     <nav class="custom-tabs__nav">
+///       <ul class="custom-tabs-nav">
+///         <li class="custom-tabs-nav__item"><a class="custom-tabs-nav__link" href="#">Item</a></li>
+///         <li class="custom-tabs-nav__item"><a class="custom-tabs-nav__link active" href="#">Item</a></li>
+///         <li class="custom-tabs-nav__item"><a class="custom-tabs-nav__link" href="#">Item</a></li>
+///       </ul>
+///     </nav>
+///   </div>
+
+%tabs {
+  position: relative;
+  width: 100%;
+
+  &__nav {
+    background-color: tab-settings(background-color);
+    border-bottom: 1px solid tab-settings(border-color);
+    overflow: hidden;
+  }
+}
+
+%tabs-nav {
+  margin: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding: 0;
+  position: relative;
+  white-space: nowrap;
+
+  &__item {
+    display: inline-block;
+    list-style: none;
+    position: relative;
+    vertical-align: top;
+  }
+
+  &__link {
+    color: tab-settings(text-color);
+    display: block;
+    font-size: tab-settings(text-size);
+    line-height: tab-settings(height);
+    margin: tab-settings(margin);
+    margin-bottom: -1px;
+    overflow: hidden;
+    padding: tab-settings(padding);
+    position: relative;
+    text-align: center;
+    transition: color tab-settings(transition-duration);
+    white-space: nowrap;
+
+    &:after {
+      background-color: tab-settings(border-color);
+      bottom: 0;
+      content: '';
+      height: tab-settings(border-height);
+      left: 0;
+      position: absolute;
+      transform: translate(0, 150%);
+      transition: transform tab-settings(transition-duration),
+        background-color tab-settings(transition-duration);
+      width: 100%;
+    }
+
+    &:hover,
+    &.active {
+      color: tab-settings(text-color-active);
+
+      &:after {
+        transform: translate(0, 0);
+      }
+    }
+
+    &.active {
+      &:after {
+        background-color: tab-settings(border-color-active);
+      }
+    }
+
+    @media #{$small-only} {
+      margin: 0;
+    }
+  }
+}
+
 @include exports('paint-tab') {
   @if $include-html-paint-tabs {
     .tabs {


### PR DESCRIPTION
This creates a set of placeholders to allow extending the tabs component past the default markup structure.

It would (for example) allow customising the item element within a custom component by using a different layout instead of the default provided.

Examples added for the documentation page as well.