### PR TITLE
[WIP] Flex grid and gutter components

### DIFF
--- a/styles/components.scss
+++ b/styles/components.scss
@@ -1,12 +1,12 @@
 @import 'components/form';
 @import 'components/dropdown';
+@import 'components/panel';
 @import 'components/flip-panel';
 @import 'components/label';
 @import 'components/layout';
 @import 'components/modal';
 @import 'components/navigation';
 @import 'components/notification';
-@import 'components/panel';
 @import 'components/progress-bar';
 @import 'components/quick-jump';
 @import 'components/side-panel';

--- a/styles/components/_flip-panel.scss
+++ b/styles/components/_flip-panel.scss
@@ -4,8 +4,6 @@
 /// @since v0.8.43
 ////
 
-@import 'panel';
-
 /// Default settings
 
 /// @example scss - Usage

--- a/styles/global/_components.scss
+++ b/styles/global/_components.scss
@@ -2,3 +2,4 @@
 @import 'components/button';
 @import 'components/typography';
 @import 'components/grid';
+@import 'components/flex-grid';

--- a/styles/global/_components.scss
+++ b/styles/global/_components.scss
@@ -1,4 +1,5 @@
 @import 'components/gutter';
+@import 'components/border';
 @import 'components/icon';
 @import 'components/button';
 @import 'components/typography';

--- a/styles/global/_components.scss
+++ b/styles/global/_components.scss
@@ -1,3 +1,4 @@
+@import 'components/gutter';
 @import 'components/icon';
 @import 'components/button';
 @import 'components/typography';

--- a/styles/global/components/_border.scss
+++ b/styles/global/components/_border.scss
@@ -1,0 +1,45 @@
+$border-prefix: '%border' !default;
+$border-color: color(border) !default;
+
+$border-placements: (
+  top: top,
+  bottom: bottom,
+  left: left,
+  right: right,
+  vertical: top bottom,
+  horizontal: left right,
+  all: top bottom left right
+);
+
+$border-colors: (
+  dark: color(border, dark),
+  light: color(border, light)
+);
+
+@mixin border($placement: bottom, $color: $border-color) {
+  @each $placement_item in $placement {
+    border-#{$placement_item}: 1px solid #{$color};
+  }
+}
+
+#{$border-prefix} {
+  @each $placement, $placement_value in $border-placements {
+    &__#{$placement} {
+      @include border($placement_value);
+    }
+
+    @each $color, $color_value in $border-colors {
+      &__#{$placement}-#{$color} {
+        @include border($placement_value, $color_value);
+      }
+    }
+  }
+
+  &--rounded {
+    border-radius: $global-radius;
+  }
+
+  &--circle {
+    border-radius: $global-rounded;
+  }
+}

--- a/styles/global/components/_flex-grid.scss
+++ b/styles/global/components/_flex-grid.scss
@@ -4,8 +4,8 @@
 /// @since v0.9.25
 ////
 
-$flex-row-prefix: 'row' !default;
-$flex-col-prefix: 'col' !default;
+$flex-row-prefix: '%row' !default;
+$flex-col-prefix: '%col' !default;
 
 @function col-width($columns, $total-columns: $grid-columns) {
   @return 100% / $total-columns * $columns;
@@ -26,23 +26,19 @@ $flex-col-prefix: 'col' !default;
 
 @mixin col-placeholders($prefix: $flex-col-prefix) {
   @for $i from 1 through $grid-columns {
-    %#{$prefix}-#{$i} {
+    #{$prefix}-#{$i} {
       @include col($i);
     }
   }
 
-  %#{$prefix}--fill {
-    flex: 1;
-  }
-
-  %#{$prefix}--auto-fill {
-    flex: auto;
+  #{$prefix}--fill {
+    flex-grow: 1;
   }
 }
 
 @mixin col-push-placeholders($prefix: $flex-col-prefix) {
   @for $i from 1 through $grid-columns {
-    %#{$prefix}-push-#{$i} {
+    #{$prefix}-push-#{$i} {
       @include col-gutter($i);
     }
   }
@@ -50,7 +46,7 @@ $flex-col-prefix: 'col' !default;
 
 @mixin col-pull-placeholders($prefix: $flex-col-prefix) {
   @for $i from 1 through $grid-columns {
-    %#{$prefix}-pull-#{$i} {
+    #{$prefix}-pull-#{$i} {
       @include col-gutter($i, right);
     }
   }
@@ -70,7 +66,7 @@ $flex-col-prefix: 'col' !default;
   }
 }
 
-%#{$flex-row-prefix} {
+#{$flex-row-prefix} {
   align-content: flex-start;
   display: flex;
 
@@ -106,21 +102,33 @@ $flex-col-prefix: 'col' !default;
     justify-content: center;
   }
 
+  &--right {
+    justify-content: flex-end;
+  }
+
   &--vertical {
     flex-direction: column;
   }
 }
 
-%#{$flex-col-prefix} {
+#{$flex-col-prefix} {
   &--no-fill {
     flex: none;
     flex-basis: auto;
+  }
+
+  &--auto-fill {
+    flex: auto;
   }
 
   &--gutter {
     &:not(:last-child) {
       margin-right: $column-gutter / 2;
     }
+  }
+
+  &--no-shrink {
+    flex-shrink: 0;
   }
 
   &--middle {

--- a/styles/global/components/_flex-grid.scss
+++ b/styles/global/components/_flex-grid.scss
@@ -1,0 +1,150 @@
+////
+/// Flex Grid placeholders
+/// @group grid
+/// @since v0.9.25
+////
+
+$flex-row-prefix: 'row' !default;
+$flex-col-prefix: 'col' !default;
+
+@function col-width($columns, $total-columns: $grid-columns) {
+  @return 100% / $total-columns * $columns;
+}
+
+@mixin col($columns) {
+  $width: col-width($columns);
+
+  flex-basis: $width;
+  max-width: $width;
+}
+
+@mixin col-gutter($columns, $direction: left, $type: margin) {
+  $width: col-width($columns);
+
+  #{$type}-#{$direction}: $width;
+}
+
+@mixin col-placeholders($prefix: $flex-col-prefix) {
+  @for $i from 1 through $grid-columns {
+    %#{$prefix}-#{$i} {
+      @include col($i);
+    }
+  }
+
+  %#{$prefix}--fill {
+    flex: 1;
+  }
+
+  %#{$prefix}--auto-fill {
+    flex: auto;
+  }
+}
+
+@mixin col-push-placeholders($prefix: $flex-col-prefix) {
+  @for $i from 1 through $grid-columns {
+    %#{$prefix}-push-#{$i} {
+      @include col-gutter($i);
+    }
+  }
+}
+
+@mixin col-pull-placeholders($prefix: $flex-col-prefix) {
+  @for $i from 1 through $grid-columns {
+    %#{$prefix}-pull-#{$i} {
+      @include col-gutter($i, right);
+    }
+  }
+}
+
+@include col-placeholders;
+@include col-push-placeholders;
+@include col-pull-placeholders;
+
+@for $i from 1 through length($grid-responsive-media-queries) {
+  $query: nth($grid-responsive-media-queries, $i);
+  $size: nth($grid-responsive-sizes, $i);
+  $prefix: '#{$flex-col-prefix}-#{$size}';
+
+  @media #{$query} {
+    @include col-placeholders($prefix: $prefix);
+  }
+}
+
+%#{$flex-row-prefix} {
+  align-content: flex-start;
+  display: flex;
+
+  &--fill {
+    width: 100%;
+  }
+
+  &--wrap {
+    flex-wrap: wrap;
+  }
+
+  &--middle {
+    align-items: center;
+  }
+
+  &--top {
+    align-items: flex-start;
+  }
+
+  &--bottom {
+    align-items: flex-end;
+  }
+
+  &--space-around {
+    justify-content: space-around;
+  }
+
+  &--space-between {
+    justify-content: space-between;
+  }
+
+  &--center {
+    justify-content: center;
+  }
+
+  &--vertical {
+    flex-direction: column;
+  }
+}
+
+%#{$flex-col-prefix} {
+  &--no-fill {
+    flex: none;
+    flex-basis: auto;
+  }
+
+  &--gutter {
+    &:not(:last-child) {
+      margin-right: $column-gutter / 2;
+    }
+  }
+
+  &--middle {
+    align-self: center;
+  }
+
+  &--top {
+    align-self: flex-start;
+  }
+
+  &--bottom {
+    align-self: flex-end;
+  }
+
+  &--right {
+    margin-left: auto;
+  }
+
+  &--left {
+    margin-right: auto;
+  }
+
+  &--center {
+    margin-left: auto;
+    margin-right: auto;
+  }
+}

--- a/styles/global/components/_gutter.scss
+++ b/styles/global/components/_gutter.scss
@@ -4,7 +4,7 @@
 /// @since v0.9.25
 ////
 
-$gutter-prefix: 'gutter' !default;
+$gutter-prefix: '%gutter' !default;
 $gutter-base: 1.5rem !default;
 
 $gutter-placements: (
@@ -30,7 +30,7 @@ $gutter-sizes: (
   }
 }
 
-%gutter {
+#{$gutter-prefix} {
   @each $placement, $placement_value in $gutter-placements {
     &__#{$placement} {
       @include gutter($placement_value, $type: padding);

--- a/styles/global/components/_gutter.scss
+++ b/styles/global/components/_gutter.scss
@@ -1,0 +1,53 @@
+////
+/// Gutter placeholders
+/// @group grid
+/// @since v0.9.25
+////
+
+$gutter-prefix: 'gutter' !default;
+$gutter-base: 1.5rem !default;
+
+$gutter-placements: (
+  top: top,
+  bottom: bottom,
+  left: left,
+  right: right,
+  vertical: top bottom,
+  horizontal: left right,
+  all: top bottom left right
+);
+
+$gutter-sizes: (
+  small: $gutter-base / 2,
+  smaller: $gutter-base / 4,
+  large: $gutter-base * 2,
+  larger: $gutter-base * 3
+);
+
+@mixin gutter($placement: left right, $size: $gutter-base, $type: margin) {
+  @each $placement_item in $placement {
+    #{$type}-#{$placement_item}: $size;
+  }
+}
+
+%gutter {
+  @each $placement, $placement_value in $gutter-placements {
+    &__#{$placement} {
+      @include gutter($placement_value, $type: padding);
+
+      &-outer {
+        @include gutter($placement_value);
+      }
+    }
+
+    @each $size, $size_value in $gutter-sizes {
+      &__#{$placement}-#{$size} {
+        @include gutter($placement_value, $size_value, $type: padding);
+
+        &-outer {
+          @include gutter($placement_value, $size_value);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
* Create a flex-only grid to slowly replace and deprecate the old one.
* Create a gutter component to allow accessing the basic paddings and margins using extends

Use case:

```scss
@include bem-block('list') {
  @extend %row; // basic row
  @extend %row--fill; // makes sure it fills the parent
  @extend %row--middle; // columns inside will be centered vertically
  @extend %row--wrap; // columns are allowed to drop on multiple lines
  @extend %gutter__horizontal; // adds a default horizontal gutter

  @include bem-element('item') {
    @extend %col-small-12;
    @extend %col-medium-6;

    background-color: color(border);

    @include bem-modifier('1') {
      @extend %col-large-6;
    }

    @include bem-modifier('2') {
      @extend %col-large--fill; // it fills the remaining area for the large screens
    }

    @include bem-modifier('3') {
      @extend %col-large--fill;
    }

    @include bem-modifier('actions') {
      @extend %col--no-fill; // clears any default widths
      @extend %col--right; // pushes the column to the right
      @extend %row; // makes sure the content inside gets displayed using flex
    }
  }
}
```

```html
  <div class="list">
    <div class="list__item list__item--1">First</div>
    <div class="list__item list__item--2">Second</div>
    <div class="list__item list__item--3">Third</div>
   
 <div class="list__item list__item--actions">
      <a class="list-action">Save</a>
      <a class="list-action">Delete</a>
    </div>
  </div>
```

![screen shot 2016-05-24 at 17 54 12](https://cloud.githubusercontent.com/assets/1321353/15512652/e3c69470-21d8-11e6-9118-85fe001795e9.png)
![screen shot 2016-05-24 at 17 56 00](https://cloud.githubusercontent.com/assets/1321353/15512651/e3b2c332-21d8-11e6-8cb3-3e20e96e47a8.png)
![screen shot 2016-05-24 at 17 56 13](https://cloud.githubusercontent.com/assets/1321353/15512653/e43b0940-21d8-11e6-96d6-12b83c12da50.png)