### PR TITLE
Typography tweaks++

### DIFF
--- a/styles/global/_flex-grid.scss
+++ b/styles/global/_flex-grid.scss
@@ -30,11 +30,16 @@ $grid: map-merge-settings($grid-defaults, $grid);
   @return 100% / $total-columns * $columns;
 }
 
-@mixin grid-col($columns) {
+@mixin grid-col($columns, $fixed: false) {
   $width: grid-col-width($columns);
 
   flex-basis: $width;
-  max-width: $width;
+
+  @if $fixed {
+    min-width: $width;
+  } @else {
+    max-width: $width;
+  }
 }
 
 @mixin grid-col-gutter($columns, $direction: left, $type: margin) {
@@ -47,6 +52,10 @@ $grid: map-merge-settings($grid-defaults, $grid);
   @for $i from 1 through grid(columns) {
     #{$prefix}-#{$i} {
       @include grid-col($i);
+
+      &-fixed {
+        @include grid-col($i, $fixed: true);
+      }
     }
   }
 

--- a/styles/global/_typography.scss
+++ b/styles/global/_typography.scss
@@ -162,7 +162,7 @@ $font: map-merge-settings($font-defaults, $font);
   }
 
   p {
-    font-feature-settings: 'kern', 'onum', 'liga';
+    font-feature-settings: 'kern', 'liga';
     margin-top: 0;
   }
 
@@ -217,7 +217,7 @@ $font: map-merge-settings($font-defaults, $font);
   ul,
   ol {
     li {
-      font-feature-settings: 'kern', 'onum', 'liga';
+      font-feature-settings: 'kern', 'liga';
 
       ol,
       ul {
@@ -292,7 +292,7 @@ $font: map-merge-settings($font-defaults, $font);
   dl {
     dt,
     dd {
-      font-feature-settings: 'kern', 'onum', 'liga';
+      font-feature-settings: 'kern', 'liga';
     }
 
     dt {


### PR DESCRIPTION
* Removes the default `onum` text setting
![screen shot 2016-08-17 at 12 35 55](https://cloud.githubusercontent.com/assets/1321353/17734917/33346236-6477-11e6-97e0-689e351ad87f.png)


* Creates a `%col-[x]-fixed paceholder` that allows a column to have a min-width instead of max-width _(documentation and usage to follow)_