### PR TITLE
Get the block name if a modifier and a pseudo-element selector are passed in the same declaration

### DIFF
--- a/styles/tools/_bem.scss
+++ b/styles/tools/_bem.scss
@@ -27,10 +27,10 @@ $bem-modifier-separator: '--';
 
 @function _bem-get-block-name($selector) {
   $selector: _bem-selector-to-string($selector);
-  $modifier-separator: $bem-modifier-separator;
+  $modifier-separator: ':';
 
-  @if str-index($selector, ':') {
-    $modifier-separator: ':';
+  @if str-index($selector, $bem-modifier-separator) {
+    $modifier-separator: $bem-modifier-separator;
   }
 
   $modifier-start: str-index($selector, $modifier-separator) - 1;

--- a/styles/tools/_bem.scss
+++ b/styles/tools/_bem.scss
@@ -6,6 +6,7 @@
 
 $bem-element-separator: '__';
 $bem-modifier-separator: '--';
+$bem-pseudo-separator: ':';
 
 @function _bem-selector-to-string($selector) {
   $selector: inspect($selector);
@@ -27,7 +28,7 @@ $bem-modifier-separator: '--';
 
 @function _bem-get-block-name($selector) {
   $selector: _bem-selector-to-string($selector);
-  $modifier-separator: ':';
+  $modifier-separator: $bem-pseudo-separator;
 
   @if str-index($selector, $bem-modifier-separator) {
     $modifier-separator: $bem-modifier-separator;


### PR DESCRIPTION
An edge case scenario where we need to use a pseudo-element selector for a modifier:

```scss
@include b('block') {
  @include m('highlighted:nth-child(2n)') {
      @include e('item') {
        background-color: color(border, light);
      }
  }
```

**Before**
The `_bem-get-block-name` function would strip only the pseudo-element from the parent modifier, generating a `.block--highlighted:nth-child(2n) .block--highlighted__item` class name for the element.

**After**
The class `.block--highlighted:nth-child(2n) .block__item` is properly returned for the edge case defined above.

