### PR TITLE
Add node-sass 4.5.1 compatibility

### DIFF
--- a/styles/components/deprecated/_form.scss
+++ b/styles/components/deprecated/_form.scss
@@ -14,7 +14,8 @@ $form-input-border-color: darken(color(white), 10%) !default;
 $form-input-border-color-focused: color(border, dark) !default;
 $form-input-disabled-bg: rgba(255, 255, 255, 0) !default;
 $form-input-height: 32px !default;
-$form-input-padding: calc($form-input-height - font(size, base)) !default;
+$form-input-padding: 'calc(#{$form-input-height} - #{font(size, base)})' !default;
+$form-input-half-padding: 'calc((#{$form-input-height} - #{font(size, base)}) / 2)' !default;
 $form-input-shadow-color: rgba(color(black), .08) !default;
 $form-input-text-color: color(text, small) !default;
 $form-input-disabled-text-color: lighten($form-input-text-color, 20%) !default;
@@ -103,7 +104,7 @@ $include-html-paint-form: true !default;
   line-height: $form-input-height;
   height: $form-input-height;
   margin-bottom: 0;
-  padding: 0 $form-input-padding / 2;
+  padding: 0 $form-input-half-padding;
   width: 100%;
 
   &::-webkit-input-placeholder {
@@ -172,7 +173,7 @@ $include-html-paint-form: true !default;
       color: $form-input-text-color;
       font-size: font(size, base);
       margin: 0;
-      padding: 0 $form-input-padding / 2;
+      padding: 0 $form-input-half-padding;
       position: relative;
       text-shadow: 0 1px color(white);
       width: 130%;
@@ -647,7 +648,7 @@ $include-html-paint-form: true !default;
   font-size: font(size, base);
   line-height: font(line-height);
   min-height: $form-input-height * 3;
-  padding: $form-input-padding / 2;
+  padding: $form-input-half-padding;
 }
 
 @mixin form-submission-action($height: false) {
@@ -786,8 +787,8 @@ $include-html-paint-form: true !default;
     height: 0;
     pointer-events: none;
     position: absolute;
-    right: $form-input-padding / 2;
-    top: ($form-input-padding + $form-select-arrow-size) / 2;
+    right: $form-input-half-padding;
+    top: 6px;
     width: 0;
   }
 

--- a/styles/tools/_bem.scss
+++ b/styles/tools/_bem.scss
@@ -52,18 +52,16 @@ $bem-pseudo-separator: ':';
     $block: _bem-get-block-name($selector);
 
     @at-root {
-      #{$selector} {
-        @each $element in $elements {
-          .#{$block + $bem-element-separator + $element} {
-            @content;
-          }
+      @each $element in $elements {
+        #{selector-parse(selector-nest(&, '.#{selector-append($block, $bem-element-separator, $element)}'))} {
+          @content;
         }
       }
     }
   } @else {
     @at-root {
       @each $element in $elements {
-        #{$selector + $bem-element-separator + $element} {
+        #{selector-append(&, $bem-element-separator, $element)} {
           @content;
         }
       }
@@ -72,9 +70,13 @@ $bem-pseudo-separator: ':';
 }
 
 @mixin m($modifier) {
-  @at-root {
-    #{&}#{$bem-modifier-separator + $modifier} {
-      @content;
-    }
+  $class-name: selector-append(&, $bem-modifier-separator, $modifier);
+
+  @if str-index($modifier, $bem-pseudo-separator) == 1 {
+    $class-name: selector-append(&, $modifier);
+  }
+
+  @at-root #{$class-name} {
+    @content;
   }
 }


### PR DESCRIPTION
### Problem
* Using the parent selector `&` inside the BEM mixins became unreliable with the latest node-sass 
* Some variables within deprecated form styles return the wrong values

### Solution
* Refactor the element and mixin to output the proper class names at root level
* Tweak the modifier mixin to allow passing pseudo-selectors as params
