### PR TITLE
[SEARCH-4565] Use default ordered list styling

### DIFF
--- a/styles/global/_typography.scss
+++ b/styles/global/_typography.scss
@@ -227,8 +227,6 @@ $font: map-merge-settings($font-defaults, $font);
   }
 
   ol {
-    list-style-type: decimal;
-
     li {
       @extend %_nested-list;
 
@@ -271,8 +269,6 @@ $font: map-merge-settings($font-defaults, $font);
   }
 
   ol {
-    list-style-type: decimal;
-
     li {
       @extend %_nested-sub-lists;
 
@@ -285,8 +281,6 @@ $font: map-merge-settings($font-defaults, $font);
 
 %_nested-o-list {
   ol {
-    list-style-type: decimal;
-
     li {
       &::before {
         content: '';
@@ -305,8 +299,6 @@ $font: map-merge-settings($font-defaults, $font);
   }
 
   ol {
-    list-style-type: decimal;
-
     li {
       &::before {
         content: '';

--- a/styles/global/_typography.scss
+++ b/styles/global/_typography.scss
@@ -227,15 +227,13 @@ $font: map-merge-settings($font-defaults, $font);
   }
 
   ol {
-    list-style-type: none;
+    list-style-type: decimal;
 
     li {
       @extend %_nested-list;
 
-      counter-increment: top-level;
-
       &::before {
-        content: counter(top-level) '.';
+        content: '';
         font-feature-settings: 'lnum', 'tnum';
         margin-left: -3rem;
         position: absolute;
@@ -273,13 +271,13 @@ $font: map-merge-settings($font-defaults, $font);
   }
 
   ol {
+    list-style-type: decimal;
+
     li {
       @extend %_nested-sub-lists;
 
-      counter-increment: sub-level;
-
       &::before {
-        content: counter(top-level) '.' counter(sub-level);
+        content: '';
       }
     }
   }
@@ -287,11 +285,11 @@ $font: map-merge-settings($font-defaults, $font);
 
 %_nested-o-list {
   ol {
-    li {
-      counter-increment: alt-level;
+    list-style-type: decimal;
 
+    li {
       &::before {
-        content: counter(alt-level) '.';
+        content: '';
       }
     }
   }
@@ -307,11 +305,11 @@ $font: map-merge-settings($font-defaults, $font);
   }
 
   ol {
-    li {
-      counter-increment: sub-sub-level;
+    list-style-type: decimal;
 
+    li {
       &::before {
-        content: counter(top-level) '.' counter(sub-level) '.' counter(sub-sub-level);
+        content: '';
       }
     }
   }


### PR DESCRIPTION
Use the default decimal list-style-type instead of 'none' with a counter for the content of the list item.